### PR TITLE
Replace call to setpgrp with setpgid

### DIFF
--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -134,7 +134,7 @@ int main( int ArgCn, char *ArgVc[] ) {
 	    // Detach daemon from terminal
 	    if ( close( 0 ) < 0 || close( 1 ) < 0 || close( 2 ) < 0
 		 || open( "/dev/null", 0 ) != 0 || dup2( 0, 1 ) < 0 || dup2( 0, 2 ) < 0
-		 || setpgrp() < 0
+		 || setpgid( 0, 0 ) < 0
 	       ) {
 		my_log( LOG_ERR, errno, "failed to detach daemon" );
 	    }


### PR DESCRIPTION
Linux and FreeBSD use a different signature for setpgrp.
Both support setpgid which replaces the now obsolete setpgrp and has the same signature on both systems.
