### PR TITLE
Use standard unsigned integer types

### DIFF
--- a/src/igmp.c
+++ b/src/igmp.c
@@ -79,7 +79,7 @@ void initIgmp() {
 /**
 *   Finds the textual name of the supplied IGMP request.
 */
-char *igmpPacketKind(u_int type, u_int code) {
+char *igmpPacketKind(unsigned int type, unsigned int code) {
     static char unknown[20];
 
     switch (type) {
@@ -232,7 +232,7 @@ void buildIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t group, i
     igmp->igmp_code         = code;
     igmp->igmp_group.s_addr = group;
     igmp->igmp_cksum        = 0;
-    igmp->igmp_cksum        = inetChksum((u_short *)igmp,
+    igmp->igmp_cksum        = inetChksum((unsigned short *)igmp,
                                          IP_HEADER_RAOPT_LEN + datalen);
 
 }

--- a/src/kern.c
+++ b/src/kern.c
@@ -82,7 +82,7 @@ void k_hdr_include(int hdrincl) {
 
 void k_set_ttl(int t) {
 #ifndef RAW_OUTPUT_IS_RAW
-    u_char ttl;
+    unsigned char ttl;
 
     ttl = t;
     if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_TTL,
@@ -94,7 +94,7 @@ void k_set_ttl(int t) {
 
 
 void k_set_loop(int l) {
-    u_char loop;
+    unsigned char loop;
 
     loop = l;
     if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_LOOP,

--- a/src/lib.c
+++ b/src/lib.c
@@ -61,9 +61,9 @@ char *fmtInAdr( char *St, struct in_addr InAdr ) {
  * Convert an IP address in u_long (network) format into a printable string.
  */
 char *inetFmt(uint32_t addr, char *s) {
-    register u_char *a;
+    register unsigned char *a;
 
-    a = (u_char *)&addr;
+    a = (unsigned char *)&addr;
     sprintf(s, "%u.%u.%u.%u", a[0], a[1], a[2], a[3]);
     return(s);
 }
@@ -74,15 +74,15 @@ char *inetFmt(uint32_t addr, char *s) {
  * string including the netmask as a number of bits.
  */
 char *inetFmts(uint32_t addr, uint32_t mask, char *s) {
-    register u_char *a, *m;
+    register unsigned char *a, *m;
     int bits;
 
     if ((addr == 0) && (mask == 0)) {
         sprintf(s, "default");
         return(s);
     }
-    a = (u_char *)&addr;
-    m = (u_char *)&mask;
+    a = (unsigned char *)&addr;
+    m = (unsigned char *)&mask;
     bits = 33 - ffs(ntohl(mask));
 
     if (m[3] != 0) sprintf(s, "%u.%u.%u.%u/%d", a[0], a[1], a[2], a[3],

--- a/src/os-dragonfly.h
+++ b/src/os-dragonfly.h
@@ -3,12 +3,12 @@
 #include <netinet/ip.h>
 #include <netinet/igmp.h>
 
-static inline u_short ip_data_len(const struct ip *ip)
+static inline unsigned short ip_data_len(const struct ip *ip)
 {
 	return ip->ip_len;
 }
 
-static inline void ip_set_len(struct ip *ip, u_short len)
+static inline void ip_set_len(struct ip *ip, unsigned short len)
 {
 	ip->ip_len = len;
 }

--- a/src/os-freebsd.h
+++ b/src/os-freebsd.h
@@ -12,12 +12,12 @@
 #define IGMP_V2_LEAVE_GROUP IGMP_HOST_LEAVE_MESSAGE
 #endif
 
-static inline u_short ip_data_len(const struct ip *ip)
+static inline unsigned short ip_data_len(const struct ip *ip)
 {
 	return ip->ip_len;
 }
 
-static inline void ip_set_len(struct ip *ip, u_short len)
+static inline void ip_set_len(struct ip *ip, unsigned short len)
 {
 	ip->ip_len = len;
 }

--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -4,12 +4,12 @@
 #include <netinet/ip.h>
 #include <netinet/igmp.h>
 
-static inline u_short ip_data_len(const struct ip *ip)
+static inline unsigned short ip_data_len(const struct ip *ip)
 {
 	return ntohs(ip->ip_len) - (ip->ip_hl << 2);
 }
 
-static inline void ip_set_len(struct ip *ip, u_short len)
+static inline void ip_set_len(struct ip *ip, unsigned short len)
 {
 	ip->ip_len = htons(len);
 }

--- a/src/os-netbsd.h
+++ b/src/os-netbsd.h
@@ -8,12 +8,12 @@
 #define IGMP_V2_MEMBERSHIP_REPORT IGMP_v2_HOST_MEMBERSHIP_REPORT
 #define IGMP_V2_LEAVE_GROUP IGMP_HOST_LEAVE_MESSAGE
 
-static inline u_short ip_data_len(const struct ip *ip)
+static inline unsigned short ip_data_len(const struct ip *ip)
 {
 	return ip->ip_len;
 }
 
-static inline void ip_set_len(struct ip *ip, u_short len)
+static inline void ip_set_len(struct ip *ip, unsigned short len)
 {
 	ip->ip_len = len;
 }

--- a/src/os-openbsd.h
+++ b/src/os-openbsd.h
@@ -10,12 +10,12 @@
 
 #define INADDR_ALLRTRS_GROUP INADDR_ALLROUTERS_GROUP
 
-static inline u_short ip_data_len(const struct ip *ip)
+static inline unsigned short ip_data_len(const struct ip *ip)
 {
 	return ntohs(ip->ip_len) - (ip->ip_hl << 2);
 }
 
-static inline void ip_set_len(struct ip *ip, u_short len)
+static inline void ip_set_len(struct ip *ip, unsigned short len)
 {
 	ip->ip_len = htons(len);
 }


### PR DESCRIPTION
Use the standard unsigned integer types instead of the non-standard
u_char, u_short and u_int.
(This fixes builds using the musl libc)

Based on:
https://github.com/alpinelinux/aports/blob/master/main/igmpproxy/0001-Use-standard-unsigned-integer-types.patch

Signed-off-by: Bernd Kuhls bernd.kuhls@t-online.de
Signed-off-by: Matt Weber matthew.weber@rockwellcollins.com
