### PR TITLE
uclinux support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_PROG_CC_C99
 
 AC_CANONICAL_HOST
 case $host_os in
-	linux*) os=linux;;
+	linux*|uclinux*) os=linux;;
 	freebsd*) os=freebsd;;
 	netbsd*) os=netbsd;;
 	openbsd*) os=openbsd;;


### PR DESCRIPTION
Added support for building against a uclinux target.

Signed-off-by: Matthew Weber matthew.weber@rockwellcollins.com
