### PR TITLE
igmp: Fix incorrect index calculation of upstream VIF

### DIFF
--- a/src/igmp.c
+++ b/src/igmp.c
@@ -169,7 +169,7 @@ void acceptIgmp(int recvlen) {
 			// Activate the route.
 			my_log(LOG_DEBUG, 0, "Route activate request from %s to %s",
 			    inetFmt(src,s1), inetFmt(dst,s2));
-			activateRoute(dst, src, upStreamVif[i]-1);
+			activateRoute(dst, src, checkVIF->index);
 			i = MAX_UPS_VIFS;
 		    }
 		}


### PR DESCRIPTION
igmpproxy uses a number of different kinds of indices to identify interfaces:

- The system interface index, as used by `IfDescVc` / `getIfByIx`. These identify and enumerate all interfaces on the system.
- The Virtual Interface Index (VIF). These identify only those   interfaces which take part in multicast routing.
- The upstream interface index, as used in `upStreamVif`, which identifies/enumerates only those interfaces that are configured as multicast upstream interfaces in igmpproxy's configuration.

`activateRoute`'s expected a VIF index for its `upstrVif` parameter, however it was being passed `upStreamVif[i]-1` (i.e. the system interface index of the upstream interface, minus one, where `i` is the current upstream interface index being iterated).

It is unclear what the logic was behind the `upStreamVif[i]-1` expression, as it existed ever since the `upstrVif` parameter was introduced in b55e0125c79fc9dbc95c6d6ab1121570f0c6f80f. igmpproxy working as expected highly depended on the system configuration and enumeration order of network interfaces.