### PR TITLE
Introduce default format for code base.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: LLVM
+Language: Cpp
+
+IndentWidth: 4
+ContinuationIndentWidth: 8
+
+ColumnLimit: 120
+
+MaxEmptyLinesToKeep: 2
+
+AllowShortFunctionsOnASingleLine: Empty
+AlwaysBreakBeforeMultilineStrings: true

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,3 +8,15 @@ ChangeLog:
 AUTHORS: ChangeLog
 	( echo "Authors and contributors, in alphabetical order: "; echo; \
 	sed -r "s/^Author: (.*)/\1/;t;d" $< | sort -u ) > $@
+
+if HAVE_CLANG_FORMAT
+
+.PHONY: reformat
+
+reformat:
+	@echo "Reformatting header files..."
+	@CLANG_FORMAT@ -style=file -i `find . -name "*.h"`
+	@echo "Reformatting C files..."
+	@CLANG_FORMAT@ -style=file -i `find . -name "*.c"`
+
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,12 @@ AC_CONFIG_SRCDIR([src/igmpproxy.c])
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC_C99
 
+AC_CHECK_PROGS(
+    [CLANG_FORMAT], [clang-format clang-format-4.0 clang-format-3.9],
+    [AC_MSG_ERROR([clang-format was not not found during configure.])]
+)
+AM_CONDITIONAL([HAVE_CLANG_FORMAT], [test -n "$CLANG_FORMAT"])
+
 AC_CANONICAL_HOST
 case $host_os in
 	linux*|uclinux*) os=linux;;

--- a/src/callout.c
+++ b/src/callout.c
@@ -32,19 +32,18 @@
 **
 */
 
-
 #include "igmpproxy.h"
 
 /* the code below implements a callout queue */
 static int id = 0;
-static struct timeOutQueue  *queue = 0; /* pointer to the beginning of timeout queue */
+static struct timeOutQueue *queue = 0; /* pointer to the beginning of timeout queue */
 
 struct timeOutQueue {
-    struct timeOutQueue    *next;   // Next event in queue
-    int                     id;
-    timer_f                 func;   // function to call
-    void                    *data;  // Data for function
-    int                     time;   // Time offset for next event
+    struct timeOutQueue *next; // Next event in queue
+    int id;
+    timer_f func; // function to call
+    void *data;   // Data for function
+    int time;     // Time offset for next event
 };
 
 // Method for dumping the Queue to the log.
@@ -70,7 +69,6 @@ void free_all_callouts(void) {
     }
 }
 
-
 /**
  * elapsed_time seconds have passed; perform all the events that should
  * happen.
@@ -90,7 +88,7 @@ void age_callout_queue(int elapsed_time) {
             if (_queue == NULL)
                 _queue = ptr;
             last = ptr;
-         }
+        }
     }
 
     queue = ptr;
@@ -103,7 +101,7 @@ void age_callout_queue(int elapsed_time) {
         _queue = _queue->next;
         my_log(LOG_DEBUG, 0, "About to call timeout %d (#%d)", ptr->id, i);
         if (ptr->func)
-             ptr->func(ptr->data);
+            ptr->func(ptr->data);
         free(ptr);
     }
 }
@@ -115,8 +113,7 @@ void age_callout_queue(int elapsed_time) {
 int timer_nextTimer(void) {
     if (queue) {
         if (queue->time < 0) {
-            my_log(LOG_WARNING, 0, "timer_nextTimer top of queue says %d", 
-                queue->time);
+            my_log(LOG_WARNING, 0, "timer_nextTimer top of queue says %d", queue->time);
             return 0;
         }
         return queue->time;
@@ -131,7 +128,7 @@ int timer_nextTimer(void) {
  *  @param data - Pointer to the function data to supply...
  */
 int timer_setTimer(int delay, timer_f action, void *data) {
-    struct timeOutQueue  *ptr, *node, *prev;
+    struct timeOutQueue *ptr, *node, *prev;
     int i = 0;
 
     /* create a node */
@@ -144,7 +141,7 @@ int timer_setTimer(int delay, timer_f action, void *data) {
     node->data = data;
     node->time = delay;
     node->next = 0;
-    node->id   = ++id;
+    node->id = ++id;
 
     prev = ptr = queue;
 
@@ -153,8 +150,7 @@ int timer_setTimer(int delay, timer_f action, void *data) {
     /* if the queue is empty, insert the node and return */
     if (!queue) {
         queue = node;
-    }
-    else {
+    } else {
         /* chase the pointer looking for the right place */
         while (ptr) {
             if (delay < ptr->time) {
@@ -162,19 +158,17 @@ int timer_setTimer(int delay, timer_f action, void *data) {
                 node->next = ptr;
                 if (ptr == queue) {
                     queue = node;
-                }
-                else {
+                } else {
                     prev->next = node;
                 }
                 ptr->time -= node->time;
-                my_log(LOG_DEBUG, 0,
-                    "Created timeout %d (#%d) - delay %d secs",
-                    node->id, i, node->time);
+                my_log(LOG_DEBUG, 0, "Created timeout %d (#%d) - delay %d secs", node->id, i, node->time);
                 debugQueue();
                 return node->id;
             } else {
                 // Continur to check nodes.
-                delay -= ptr->time; node->time = delay;
+                delay -= ptr->time;
+                node->time = delay;
                 prev = ptr;
                 ptr = ptr->next;
             }
@@ -182,8 +176,7 @@ int timer_setTimer(int delay, timer_f action, void *data) {
         }
         prev->next = node;
     }
-    my_log(LOG_DEBUG, 0, "Created timeout %d (#%d) - delay %d secs",
-            node->id, i, node->time);
+    my_log(LOG_DEBUG, 0, "Created timeout %d (#%d) - delay %d secs", node->id, i, node->time);
     debugQueue();
 
     return node->id;
@@ -211,8 +204,8 @@ int timer_leftTimer(int timer_id) {
 /**
 *   clears the associated timer.  Returns 1 if succeeded.
 */
-int timer_clearTimer(int  timer_id) {
-    struct timeOutQueue  *ptr, *prev;
+int timer_clearTimer(int timer_id) {
+    struct timeOutQueue *ptr, *prev;
     int i = 0;
 
     if (!timer_id)
@@ -261,7 +254,7 @@ int timer_clearTimer(int  timer_id) {
  * debugging utility
  */
 static void debugQueue(void) {
-    struct timeOutQueue  *ptr;
+    struct timeOutQueue *ptr;
 
     for (ptr = queue; ptr; ptr = ptr->next) {
         my_log(LOG_DEBUG, 0, "(Id:%d, Time:%d) ", ptr->id, ptr->time);

--- a/src/confread.c
+++ b/src/confread.c
@@ -45,22 +45,23 @@
 
 #include "igmpproxy.h"
 
-#define READ_BUFFER_SIZE    512     // Inputbuffer size...
+#define READ_BUFFER_SIZE 512 // Inputbuffer size...
 
 #ifndef MAX_TOKEN_LENGTH
-    #define MAX_TOKEN_LENGTH  30    // Default max token length
+#define MAX_TOKEN_LENGTH 30 // Default max token length
 #endif
 
-FILE            *confFilePtr;       // File handle pointer
-char            *iBuffer;           // Inputbuffer for reading...
-unsigned int    bufPtr;             // Buffer position pointer.
-unsigned int    readSize;           // Number of bytes in buffer after last read...
-char    cToken[MAX_TOKEN_LENGTH];   // Token buffer...
-short   validToken;
+FILE *confFilePtr;             // File handle pointer
+char *iBuffer;                 // Inputbuffer for reading...
+unsigned int bufPtr;           // Buffer position pointer.
+unsigned int readSize;         // Number of bytes in buffer after last read...
+char cToken[MAX_TOKEN_LENGTH]; // Token buffer...
+short validToken;
 
-/**
-*   Opens config file specified by filename.
-*/
+
+/*******************************************************************************
+ * Opens config file specified by filename.
+ ******************************************************************************/
 int openConfigFile(char *filename) {
 
     // Set the buffer to null initially...
@@ -70,14 +71,14 @@ int openConfigFile(char *filename) {
     confFilePtr = fopen(filename, "r");
 
     // On error, return false
-    if(confFilePtr == NULL) {
+    if (confFilePtr == NULL) {
         return 0;
     }
 
     // Allocate memory for inputbuffer...
-    iBuffer = (char*) malloc( sizeof(char) * READ_BUFFER_SIZE );
+    iBuffer = (char *)malloc(sizeof(char) * READ_BUFFER_SIZE);
 
-    if(iBuffer == NULL) {
+    if (iBuffer == NULL) {
         closeConfigFile();
         return 0;
     }
@@ -89,70 +90,74 @@ int openConfigFile(char *filename) {
     return 1;
 }
 
-/**
-*   Closes the currently open config file.
-*/
+/*******************************************************************************
+ * Closes the currently open config file.
+ ******************************************************************************/
 void closeConfigFile(void) {
     // Close the file.
-    if(confFilePtr!=NULL) {
+    if (confFilePtr != NULL) {
         fclose(confFilePtr);
     }
     // Free input buffer memory...
-    if(iBuffer != NULL) {
+    if (iBuffer != NULL) {
         free(iBuffer);
     }
 }
 
-/**
-*   Returns the next token from the configfile. The function
-*   return NULL if there are no more tokens in the file.
-*/
+
+/*******************************************************************************
+ * Returns the next token from the configfile.
+ * The function return NULL if there are no more tokens in the file.
+ ******************************************************************************/
 char *nextConfigToken(void) {
 
     validToken = 0;
 
     // If no file or buffer, return NULL
-    if(confFilePtr == NULL || iBuffer == NULL) {
+    if (confFilePtr == NULL || iBuffer == NULL) {
         return NULL;
     }
 
     {
-        unsigned int tokenPtr       = 0;
-        unsigned short finished     = 0;
+        unsigned int tokenPtr = 0;
+        unsigned short finished = 0;
         unsigned short commentFound = 0;
 
         // Outer buffer fill loop...
-        while ( !finished ) {
-            // If readpointer is at the end of the buffer, we should read next chunk...
-            if(bufPtr == readSize) {
+        while (!finished) {
+            /*
+             *  If readpointer is at the end of the buffer, we should read next
+             *  chunk...
+             */
+            if (bufPtr == readSize) {
                 // Fill up the buffer...
-                readSize = fread (iBuffer, sizeof(char), READ_BUFFER_SIZE, confFilePtr);
+                readSize = fread(iBuffer, sizeof(char), READ_BUFFER_SIZE, confFilePtr);
                 bufPtr = 0;
 
                 // If the readsize is 0, we should just return...
-                if(readSize == 0) {
+                if (readSize == 0) {
                     return NULL;
                 }
             }
 
             // Inner char loop...
-            while ( bufPtr < readSize && !finished ) {
+            while (bufPtr < readSize && !finished) {
 
-                //printf("Char %s", iBuffer[bufPtr]);
+                // printf("Char %s", iBuffer[bufPtr]);
 
                 // Break loop on \0
-                if(iBuffer[bufPtr] == '\0') {
+                if (iBuffer[bufPtr] == '\0') {
                     break;
                 }
 
-                if( commentFound ) {
-                    if( iBuffer[bufPtr] == '\n' ) {
+                if (commentFound) {
+                    if (iBuffer[bufPtr] == '\n') {
                         commentFound = 0;
                     }
                 } else {
 
                     // Check current char...
-                    switch(iBuffer[bufPtr]) {
+                    switch (iBuffer[bufPtr]) {
                     case '#':
                         // Found a comment start...
                         commentFound = 1;
@@ -163,8 +168,8 @@ char *nextConfigToken(void) {
                     case '\t':
                     case ' ':
                         // Newline, CR, Tab and space are end of token, or ignored.
-                        if(tokenPtr > 0) {
-                            cToken[tokenPtr] = '\0';    // EOL
+                        if (tokenPtr > 0) {
+                            cToken[tokenPtr] = '\0'; // EOL
                             finished = 1;
                         }
                         break;
@@ -177,7 +182,7 @@ char *nextConfigToken(void) {
                 }
 
                 // Check end of token buffer !!!
-                if(tokenPtr == MAX_TOKEN_LENGTH - 1) {
+                if (tokenPtr == MAX_TOKEN_LENGTH - 1) {
                     // Prevent buffer overrun...
                     cToken[tokenPtr] = '\0';
                     finished = 1;
@@ -187,14 +192,14 @@ char *nextConfigToken(void) {
                 bufPtr++;
             }
             // If the readsize is less than buffersize, we assume EOF.
-            if(readSize < READ_BUFFER_SIZE && bufPtr == readSize) {
+            if (readSize < READ_BUFFER_SIZE && bufPtr == readSize) {
                 if (tokenPtr > 0)
                     finished = 1;
                 else
                     return NULL;
             }
         }
-        if(tokenPtr>0) {
+        if (tokenPtr > 0) {
             validToken = 1;
             return cToken;
         }
@@ -202,11 +207,9 @@ char *nextConfigToken(void) {
     return NULL;
 }
 
-
-/**
-*   Returns the currently active token, or null
-*   if no tokens are available.
-*/
+/*******************************************************************************
+ * Returns the currently active token, or null if no tokens are available.
+ ******************************************************************************/
 char *getCurrentConfigToken(void) {
     return validToken ? cToken : NULL;
 }

--- a/src/ifvc.c
+++ b/src/ifvc.c
@@ -34,28 +34,32 @@
 
 #include "igmpproxy.h"
 
-struct IfDesc IfDescVc[ MAX_IF ], *IfDescEp = IfDescVc;
+struct IfDesc IfDescVc[MAX_IF], *IfDescEp = IfDescVc;
 
 /* aimwang: add for detect interface and rebuild IfVc record */
-/***************************************************
- * TODO:    Only need run me when detect downstream changed.
- *          For example: /etc/ppp/ip-up & ip-down can touch a file /tmp/ppp_changed
- *          So I can check if the file exist then run me and delete the file.
- ***************************************************/
-void rebuildIfVc () {
-    struct ifreq IfVc[ sizeof( IfDescVc ) / sizeof( IfDescVc[ 0 ] )  ];
+/*******************************************************************************
+ * TODO:
+ *  Only need run me when detect downstream changed.
+ *
+ *  For example:
+ *      /etc/ppp/ip-up & ip-down can touch a file /tmp/ppp_changed
+ *
+ * So I can check if the file exist then run me and delete the file.
+ ******************************************************************************/
+void rebuildIfVc() {
+    struct ifreq IfVc[sizeof(IfDescVc) / sizeof(IfDescVc[0])];
     struct ifreq *IfEp;
     struct ifconf IoCtlReq;
     struct IfDesc *Dp;
-    struct ifreq  *IfPt, *IfNext;
+    struct ifreq *IfPt, *IfNext;
     uint32_t addr, subnet, mask;
     int Sock, Ix;
 
     // Get the config.
     struct Config *config = getCommonConfig();
 
-    if ( (Sock = socket( AF_INET, SOCK_DGRAM, 0 )) < 0 )
-        my_log( LOG_ERR, errno, "RAW socket open" );
+    if ((Sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+        my_log(LOG_ERR, errno, "RAW socket open");
 
     // aimwang: set all downstream IF as lost, for check IF exist or gone.
     for (Dp = IfDescVc; Dp < IfDescEp; Dp++) {
@@ -65,24 +69,24 @@ void rebuildIfVc () {
     }
 
     IoCtlReq.ifc_buf = (void *)IfVc;
-    IoCtlReq.ifc_len = sizeof( IfVc );
+    IoCtlReq.ifc_len = sizeof(IfVc);
 
-    if ( ioctl( Sock, SIOCGIFCONF, &IoCtlReq ) < 0 )
-        my_log( LOG_ERR, errno, "ioctl SIOCGIFCONF" );
+    if (ioctl(Sock, SIOCGIFCONF, &IoCtlReq) < 0)
+        my_log(LOG_ERR, errno, "ioctl SIOCGIFCONF");
 
     IfEp = (void *)((char *)IfVc + IoCtlReq.ifc_len);
 
-    for ( IfPt = IfVc; IfPt < IfEp; IfPt = IfNext ) {
+    for (IfPt = IfVc; IfPt < IfEp; IfPt = IfNext) {
         struct ifreq IfReq;
-        char FmtBu[ 32 ];
+        char FmtBu[32];
 
         IfNext = (struct ifreq *)((char *)&IfPt->ifr_addr +
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
-                IfPt->ifr_addr.sa_len
+                                  IfPt->ifr_addr.sa_len
 #else
-                sizeof(struct sockaddr_in)
+                                  sizeof(struct sockaddr_in)
 #endif
-        );
+                                  );
         if (IfNext < IfPt + 1)
             IfNext = IfPt + 1;
 
@@ -93,14 +97,14 @@ void rebuildIfVc () {
         }
 
         if (Dp == IfDescEp) {
-            strncpy( Dp->Name, IfPt->ifr_name, sizeof( IfDescEp->Name ) );
+            strncpy(Dp->Name, IfPt->ifr_name, sizeof(IfDescEp->Name));
         }
 
-        if ( IfPt->ifr_addr.sa_family != AF_INET ) {
+        if (IfPt->ifr_addr.sa_family != AF_INET) {
             if (Dp == IfDescEp) {
                 IfDescEp++;
             }
-            Dp->InAdr.s_addr = 0;  /* mark as non-IP interface */
+            Dp->InAdr.s_addr = 0; /* mark as non-IP interface */
             continue;
         }
 
@@ -108,23 +112,22 @@ void rebuildIfVc () {
         Dp->InAdr = ((struct sockaddr_in *)&IfPt->ifr_addr)->sin_addr;
         addr = Dp->InAdr.s_addr;
 
-        memcpy( IfReq.ifr_name, Dp->Name, sizeof( IfReq.ifr_name ) );
+        memcpy(IfReq.ifr_name, Dp->Name, sizeof(IfReq.ifr_name));
         IfReq.ifr_addr.sa_family = AF_INET;
         ((struct sockaddr_in *)&IfReq.ifr_addr)->sin_addr.s_addr = addr;
 
         // Get the subnet mask...
-        if (ioctl(Sock, SIOCGIFNETMASK, &IfReq ) < 0)
+        if (ioctl(Sock, SIOCGIFNETMASK, &IfReq) < 0)
             my_log(LOG_ERR, errno, "ioctl SIOCGIFNETMASK for %s", IfReq.ifr_name);
         mask = ((struct sockaddr_in *)&IfReq.ifr_addr)->sin_addr.s_addr;
         subnet = addr & mask;
 
-        if ( ioctl( Sock, SIOCGIFFLAGS, &IfReq ) < 0 )
-            my_log( LOG_ERR, errno, "ioctl SIOCGIFFLAGS" );
+        if (ioctl(Sock, SIOCGIFFLAGS, &IfReq) < 0)
+            my_log(LOG_ERR, errno, "ioctl SIOCGIFFLAGS");
         Dp->Flags = IfReq.ifr_flags;
 
-        if (0x10d1 == Dp->Flags)
-        {
-            if ( ioctl( Sock, SIOCGIFDSTADDR, &IfReq ) < 0 )
+        if (0x10d1 == Dp->Flags) {
+            if (ioctl(Sock, SIOCGIFDSTADDR, &IfReq) < 0)
                 my_log(LOG_ERR, errno, "ioctl SIOCGIFDSTADDR for %s", IfReq.ifr_name);
             addr = ((struct sockaddr_in *)&IfReq.ifr_dstaddr)->sin_addr.s_addr;
             subnet = addr & mask;
@@ -133,14 +136,14 @@ void rebuildIfVc () {
         if (Dp == IfDescEp) {
             // Insert the verified subnet as an allowed net...
             Dp->allowednets = (struct SubnetList *)malloc(sizeof(struct SubnetList));
-            if(IfDescEp->allowednets == NULL) {
+            if (IfDescEp->allowednets == NULL) {
                 my_log(LOG_ERR, 0, "Out of memory !");
             }
             Dp->allowednets->next = NULL;
-            Dp->state         = IF_STATE_DOWNSTREAM;
-            Dp->robustness    = DEFAULT_ROBUSTNESS;
-            Dp->threshold     = DEFAULT_THRESHOLD;   /* ttl limit */
-            Dp->ratelimit     = DEFAULT_RATELIMIT;
+            Dp->state = IF_STATE_DOWNSTREAM;
+            Dp->robustness = DEFAULT_ROBUSTNESS;
+            Dp->threshold = DEFAULT_THRESHOLD; /* ttl limit */
+            Dp->ratelimit = DEFAULT_RATELIMIT;
         }
 
         // Set the network address for the IF..
@@ -149,7 +152,7 @@ void rebuildIfVc () {
 
         // Set the state for the IF...
         if (Dp->state == IF_STATE_LOST) {
-            Dp->state         = IF_STATE_DOWNSTREAM;
+            Dp->state = IF_STATE_DOWNSTREAM;
         }
 
         // when IF become enabeld from downstream, addVIF to enable its VIF
@@ -170,11 +173,8 @@ void rebuildIfVc () {
         }
 
         // Debug log the result...
-        my_log( LOG_DEBUG, 0, "rebuildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s",
-            Dp->Name,
-            fmtInAdr( FmtBu, Dp->InAdr ),
-            Dp->Flags,
-            inetFmts(subnet, mask, s1));
+        my_log(LOG_DEBUG, 0, "rebuildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s", Dp->Name,
+               fmtInAdr(FmtBu, Dp->InAdr), Dp->Flags, inetFmts(subnet, mask, s1));
     }
 
     // aimwang: search not longer exist IF, set as hidden and call delVIF
@@ -182,28 +182,29 @@ void rebuildIfVc () {
         if (IF_STATE_LOST == Dp->state) {
             my_log(LOG_NOTICE, 0, "%s [Downstream -> Hidden]", Dp->Name);
             Dp->state = IF_STATE_HIDDEN;
-            leaveMcGroup( getMcGroupSock(), Dp, allrouters_group );
+            leaveMcGroup(getMcGroupSock(), Dp, allrouters_group);
             delVIF(Dp);
         }
     }
 
-    close( Sock );
+    close(Sock);
 }
 
-/*
-** Builds up a vector with the interface of the machine. Calls to the other functions of
-** the module will fail if they are called before the vector is build.
-**
-*/
+/*******************************************************************************
+ *
+ * Builds up a vector with the interface of the machine. Calls to the other
+ * functions of the module will fail if they are called before the vector is build.
+ *
+ ******************************************************************************/
 void buildIfVc(void) {
-    struct ifreq IfVc[ sizeof( IfDescVc ) / sizeof( IfDescVc[ 0 ] )  ];
+    struct ifreq IfVc[sizeof(IfDescVc) / sizeof(IfDescVc[0])];
     struct ifreq *IfEp;
     struct Config *config = getCommonConfig();
 
     int Sock;
 
-    if ( (Sock = socket( AF_INET, SOCK_DGRAM, 0 )) < 0 )
-        my_log( LOG_ERR, errno, "RAW socket open" );
+    if ((Sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+        my_log(LOG_ERR, errno, "RAW socket open");
 
     /* get If vector
      */
@@ -211,48 +212,47 @@ void buildIfVc(void) {
         struct ifconf IoCtlReq;
 
         IoCtlReq.ifc_buf = (void *)IfVc;
-        IoCtlReq.ifc_len = sizeof( IfVc );
+        IoCtlReq.ifc_len = sizeof(IfVc);
 
-        if ( ioctl( Sock, SIOCGIFCONF, &IoCtlReq ) < 0 )
-            my_log( LOG_ERR, errno, "ioctl SIOCGIFCONF" );
+        if (ioctl(Sock, SIOCGIFCONF, &IoCtlReq) < 0)
+            my_log(LOG_ERR, errno, "ioctl SIOCGIFCONF");
 
         IfEp = (void *)((char *)IfVc + IoCtlReq.ifc_len);
     }
 
-    /* loop over interfaces and copy interface info to IfDescVc
-     */
+    // loop over interfaces and copy interface info to IfDescVc
     {
-        struct ifreq  *IfPt, *IfNext;
+        struct ifreq *IfPt, *IfNext;
 
         // Temp keepers of interface params...
         uint32_t addr, subnet, mask;
 
-        for ( IfPt = IfVc; IfPt < IfEp; IfPt = IfNext ) {
+        for (IfPt = IfVc; IfPt < IfEp; IfPt = IfNext) {
             struct ifreq IfReq;
-            char FmtBu[ 32 ];
+            char FmtBu[32];
 
             IfNext = (struct ifreq *)((char *)&IfPt->ifr_addr +
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
-                    IfPt->ifr_addr.sa_len
+                                      IfPt->ifr_addr.sa_len
 #else
-                    sizeof(struct sockaddr_in)
+                                      sizeof(struct sockaddr_in)
 #endif
-            );
-        if (IfNext < IfPt + 1)
-            IfNext = IfPt + 1;
+                                      );
+            if (IfNext < IfPt + 1)
+                IfNext = IfPt + 1;
 
-            strncpy( IfDescEp->Name, IfPt->ifr_name, sizeof( IfDescEp->Name ) );
+            strncpy(IfDescEp->Name, IfPt->ifr_name, sizeof(IfDescEp->Name));
 
             // Currently don't set any allowed nets...
-            //IfDescEp->allowednets = NULL;
+            // IfDescEp->allowednets = NULL;
 
             // Set the index to -1 by default.
             IfDescEp->index = -1;
 
             /* don't retrieve more info for non-IP interfaces
              */
-            if ( IfPt->ifr_addr.sa_family != AF_INET ) {
-                IfDescEp->InAdr.s_addr = 0;  /* mark as non-IP interface */
+            if (IfPt->ifr_addr.sa_family != AF_INET) {
+                IfDescEp->InAdr.s_addr = 0; /* mark as non-IP interface */
                 IfDescEp++;
                 continue;
             }
@@ -261,34 +261,34 @@ void buildIfVc(void) {
             IfDescEp->InAdr = ((struct sockaddr_in *)&IfPt->ifr_addr)->sin_addr;
             addr = IfDescEp->InAdr.s_addr;
 
-            memcpy( IfReq.ifr_name, IfDescEp->Name, sizeof( IfReq.ifr_name ) );
+            memcpy(IfReq.ifr_name, IfDescEp->Name, sizeof(IfReq.ifr_name));
             IfReq.ifr_addr.sa_family = AF_INET;
             ((struct sockaddr_in *)&IfReq.ifr_addr)->sin_addr.s_addr = addr;
 
             // Get the subnet mask...
-            if (ioctl(Sock, SIOCGIFNETMASK, &IfReq ) < 0)
+            if (ioctl(Sock, SIOCGIFNETMASK, &IfReq) < 0)
                 my_log(LOG_ERR, errno, "ioctl SIOCGIFNETMASK for %s", IfReq.ifr_name);
             mask = ((struct sockaddr_in *)&IfReq.ifr_addr)->sin_addr.s_addr;
             subnet = addr & mask;
 
-            /* get if flags
+            /*
+            ** get if flags
             **
             ** typical flags:
-            ** lo    0x0049 -> Running, Loopback, Up
-            ** ethx  0x1043 -> Multicast, Running, Broadcast, Up
-            ** ipppx 0x0091 -> NoArp, PointToPoint, Up
-            ** grex  0x00C1 -> NoArp, Running, Up
-            ** ipipx 0x00C1 -> NoArp, Running, Up
+            **  lo    0x0049 -> Running, Loopback, Up
+            **  ethx  0x1043 -> Multicast, Running, Broadcast, Up
+            **  ipppx 0x0091 -> NoArp, PointToPoint, Up
+            **  grex  0x00C1 -> NoArp, Running, Up
+            **  ipipx 0x00C1 -> NoArp, Running, Up
             */
-            if ( ioctl( Sock, SIOCGIFFLAGS, &IfReq ) < 0 )
-                my_log( LOG_ERR, errno, "ioctl SIOCGIFFLAGS" );
+            if (ioctl(Sock, SIOCGIFFLAGS, &IfReq) < 0)
+                my_log(LOG_ERR, errno, "ioctl SIOCGIFFLAGS");
 
             IfDescEp->Flags = IfReq.ifr_flags;
 
             // aimwang: when pppx get dstaddr for use
-            if (0x10d1 == IfDescEp->Flags)
-            {
-                if ( ioctl( Sock, SIOCGIFDSTADDR, &IfReq ) < 0 )
+            if (0x10d1 == IfDescEp->Flags) {
+                if (ioctl(Sock, SIOCGIFDSTADDR, &IfReq) < 0)
                     my_log(LOG_ERR, errno, "ioctl SIOCGIFDSTADDR for %s", IfReq.ifr_name);
                 addr = ((struct sockaddr_in *)&IfReq.ifr_dstaddr)->sin_addr.s_addr;
                 subnet = addr & mask;
@@ -296,7 +296,8 @@ void buildIfVc(void) {
 
             // Insert the verified subnet as an allowed net...
             IfDescEp->allowednets = (struct SubnetList *)malloc(sizeof(struct SubnetList));
-            if(IfDescEp->allowednets == NULL) my_log(LOG_ERR, 0, "Out of memory !");
+            if (IfDescEp->allowednets == NULL)
+                my_log(LOG_ERR, 0, "Out of memory !");
 
             // Create the network address for the IF..
             IfDescEp->allowednets->next = NULL;
@@ -304,71 +305,72 @@ void buildIfVc(void) {
             IfDescEp->allowednets->subnet_addr = subnet;
 
             // Set the default params for the IF...
-            IfDescEp->state         = config->defaultInterfaceState;
-            IfDescEp->robustness    = DEFAULT_ROBUSTNESS;
-            IfDescEp->threshold     = DEFAULT_THRESHOLD;   /* ttl limit */
-            IfDescEp->ratelimit     = DEFAULT_RATELIMIT;
+            IfDescEp->state = config->defaultInterfaceState;
+            IfDescEp->robustness = DEFAULT_ROBUSTNESS;
+            IfDescEp->threshold = DEFAULT_THRESHOLD; /* ttl limit */
+            IfDescEp->ratelimit = DEFAULT_RATELIMIT;
 
             // Debug log the result...
-            my_log( LOG_DEBUG, 0, "buildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s",
-                 IfDescEp->Name,
-                 fmtInAdr( FmtBu, IfDescEp->InAdr ),
-                 IfDescEp->Flags,
-                 inetFmts(subnet,mask, s1));
+            my_log(LOG_DEBUG, 0, "buildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s", IfDescEp->Name,
+                   fmtInAdr(FmtBu, IfDescEp->InAdr), IfDescEp->Flags, inetFmts(subnet, mask, s1));
 
             IfDescEp++;
         }
     }
 
-    close( Sock );
+    close(Sock);
 }
 
-/*
-** Returns a pointer to the IfDesc of the interface 'IfName'
-**
-** returns: - pointer to the IfDesc of the requested interface
-**          - NULL if no interface 'IfName' exists
-**
-*/
-struct IfDesc *getIfByName( const char *IfName ) {
+
+/*******************************************************************************
+ * Returns a pointer to the IfDesc of the interface 'IfName'
+ *
+ * returns: - pointer to the IfDesc of the requested interface
+ *          - NULL if no interface 'IfName' exists
+ *
+ ******************************************************************************/
+struct IfDesc *getIfByName(const char *IfName) {
     struct IfDesc *Dp;
 
-    for ( Dp = IfDescVc; Dp < IfDescEp; Dp++ )
-        if ( ! strcmp( IfName, Dp->Name ) )
+    for (Dp = IfDescVc; Dp < IfDescEp; Dp++)
+        if (!strcmp(IfName, Dp->Name))
             return Dp;
 
     return NULL;
 }
 
-/*
-** Returns a pointer to the IfDesc of the interface 'Ix'
-**
-** returns: - pointer to the IfDesc of the requested interface
-**          - NULL if no interface 'Ix' exists
-**
-*/
-struct IfDesc *getIfByIx( unsigned Ix ) {
-    struct IfDesc *Dp = &IfDescVc[ Ix ];
+
+/*******************************************************************************
+ * Returns a pointer to the IfDesc of the interface 'Ix'
+ *
+ * returns: - pointer to the IfDesc of the requested interface
+ *          - NULL if no interface 'Ix' exists
+ *
+ ******************************************************************************/
+struct IfDesc *getIfByIx(unsigned Ix) {
+    struct IfDesc *Dp = &IfDescVc[Ix];
     return Dp < IfDescEp ? Dp : NULL;
 }
 
-/**
-*   Returns a pointer to the IfDesc whose subnet matches
-*   the supplied IP adress. The IP must match a interfaces
-*   subnet, or any configured allowed subnet on a interface.
-*/
-struct IfDesc *getIfByAddress( uint32_t ipaddr ) {
 
-    struct IfDesc       *Dp;
-    struct SubnetList   *currsubnet;
-    struct IfDesc       *res = NULL;
-    uint32_t            last_subnet_mask = 0;
+/*******************************************************************************
+ * Returns a pointer to the IfDesc whose subnet matches the supplied IP address.
+ * The IP must match a interfaces subnet, or any configured allowed subnet on a interface.
+ *
+ ******************************************************************************/
+struct IfDesc *getIfByAddress(uint32_t ipaddr) {
 
-    for ( Dp = IfDescVc; Dp < IfDescEp; Dp++ ) {
+    struct IfDesc *Dp;
+    struct SubnetList *currsubnet;
+    struct IfDesc *res = NULL;
+    uint32_t last_subnet_mask = 0;
+
+    for (Dp = IfDescVc; Dp < IfDescEp; Dp++) {
         // Loop through all registered allowed nets of the VIF...
-        for(currsubnet = Dp->allowednets; currsubnet != NULL; currsubnet = currsubnet->next) {
+        for (currsubnet = Dp->allowednets; currsubnet != NULL; currsubnet = currsubnet->next) {
             // Check if the ip falls in under the subnet....
-            if(currsubnet->subnet_mask > last_subnet_mask && (ipaddr & currsubnet->subnet_mask) == currsubnet->subnet_addr) {
+            if (currsubnet->subnet_mask > last_subnet_mask &&
+                (ipaddr & currsubnet->subnet_mask) == currsubnet->subnet_addr) {
                 res = Dp;
                 last_subnet_mask = currsubnet->subnet_mask;
             }
@@ -378,16 +380,16 @@ struct IfDesc *getIfByAddress( uint32_t ipaddr ) {
 }
 
 
-/**
-*   Returns a pointer to the IfDesc whose subnet matches
-*   the supplied IP adress. The IP must match a interfaces
-*   subnet, or any configured allowed subnet on a interface.
-*/
-struct IfDesc *getIfByVifIndex( unsigned vifindex ) {
-    struct IfDesc       *Dp;
-    if(vifindex>0) {
-        for ( Dp = IfDescVc; Dp < IfDescEp; Dp++ ) {
-            if(Dp->index == vifindex) {
+/*******************************************************************************
+ *  Returns a pointer to the IfDesc whose subnet matches the supplied IP address.
+ *  The IP must match a interfaces subnet, or any configured allowed subnet on a interface.
+ *
+ ******************************************************************************/
+struct IfDesc *getIfByVifIndex(unsigned vifindex) {
+    struct IfDesc *Dp;
+    if (vifindex > 0) {
+        for (Dp = IfDescVc; Dp < IfDescEp; Dp++) {
+            if (Dp->index == vifindex) {
                 return Dp;
             }
         }
@@ -396,21 +398,22 @@ struct IfDesc *getIfByVifIndex( unsigned vifindex ) {
 }
 
 
-/**
+/*******************************************************************************
 *   Function that checks if a given ipaddress is a valid
 *   address for the supplied VIF.
-*/
-int isAdressValidForIf( struct IfDesc* intrface, uint32_t ipaddr ) {
-    struct SubnetList   *currsubnet;
+ *
+ ******************************************************************************/
+int isAdressValidForIf(struct IfDesc *intrface, uint32_t ipaddr) {
+    struct SubnetList *currsubnet;
 
-    if(intrface == NULL) {
+    if (intrface == NULL) {
         return 0;
     }
 
     // Loop through all registered allowed nets of the VIF...
-    for(currsubnet = intrface->allowednets; currsubnet != NULL; currsubnet = currsubnet->next) {
+    for (currsubnet = intrface->allowednets; currsubnet != NULL; currsubnet = currsubnet->next) {
         // Check if the ip falls in under the subnet....
-        if((ipaddr & currsubnet->subnet_mask) == (currsubnet->subnet_addr& currsubnet->subnet_mask)) {
+        if ((ipaddr & currsubnet->subnet_mask) == (currsubnet->subnet_addr & currsubnet->subnet_mask)) {
             return 1;
         }
     }

--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -40,37 +40,35 @@
 #include "igmpproxy.h"
 
 static const char Usage[] =
-"Usage: igmpproxy [-h] [-d] [-v [-v]] <configfile>\n"
-"\n"
-"   -h   Display this help screen\n"
-"   -d   Run in debug mode. Output all messages on stderr\n"
-"   -v   Be verbose. Give twice to see even debug messages.\n"
-"\n"
-PACKAGE_STRING "\n"
-;
+        "Usage: igmpproxy [-h] [-d] [-v [-v]] <configfile>\n"
+        "\n"
+        "   -h   Display this help screen\n"
+        "   -d   Run in debug mode. Output all messages on stderr\n"
+        "   -v   Be verbose. Give twice to see even debug messages.\n"
+        "\n" PACKAGE_STRING "\n";
 
 // Local function Prototypes
 static void signalHandler(int);
-int     igmpProxyInit(void);
-void    igmpProxyCleanUp(void);
-void    igmpProxyRun(void);
+int igmpProxyInit(void);
+void igmpProxyCleanUp(void);
+void igmpProxyRun(void);
 
 // Global vars...
 static int sighandled = 0;
-#define GOT_SIGINT  0x01
-#define GOT_SIGHUP  0x02
+#define GOT_SIGINT 0x01
+#define GOT_SIGHUP 0x02
 #define GOT_SIGUSR1 0x04
 #define GOT_SIGUSR2 0x08
 
 // Holds the indeces of the upstream IF...
-int     upStreamIfIdx[MAX_UPS_VIFS];
+int upStreamIfIdx[MAX_UPS_VIFS];
 
 /**
 *   Program main method. Is invoked when the program is started
 *   on commandline. The number of commandline arguments, and a
 *   pointer to the arguments are received on the line...
 */
-int main( int ArgCn, char *ArgVc[] ) {
+int main(int ArgCn, char *ArgVc[]) {
 
     int c;
 
@@ -104,40 +102,39 @@ int main( int ArgCn, char *ArgVc[] ) {
 
     // Chech that we are root
     if (geteuid() != 0) {
-       fprintf(stderr, "igmpproxy: must be root\n");
-       exit(1);
+        fprintf(stderr, "igmpproxy: must be root\n");
+        exit(1);
     }
 
     openlog("igmpproxy", LOG_PID, LOG_USER);
 
     // Write debug notice with file path...
-    my_log(LOG_DEBUG, 0, "Searching for config file at '%s'" , configFilePath);
+    my_log(LOG_DEBUG, 0, "Searching for config file at '%s'", configFilePath);
 
     do {
 
         // Loads the config file...
-        if( ! loadConfig( configFilePath ) ) {
+        if (!loadConfig(configFilePath)) {
             my_log(LOG_ERR, 0, "Unable to load config file...");
             break;
         }
 
         // Initializes the deamon.
-        if ( !igmpProxyInit() ) {
+        if (!igmpProxyInit()) {
             my_log(LOG_ERR, 0, "Unable to initialize IGMPproxy.");
             break;
         }
 
-        if ( !Log2Stderr ) {
+        if (!Log2Stderr) {
 
             // Only daemon goes past this line...
-            if (fork()) exit(0);
+            if (fork())
+                exit(0);
 
             // Detach daemon from terminal
-            if ( close( 0 ) < 0 || close( 1 ) < 0 || close( 2 ) < 0
-                || open( "/dev/null", 0 ) != 0 || dup2( 0, 1 ) < 0 || dup2( 0, 2 ) < 0
-                || setpgid( 0, 0 ) < 0
-            ) {
-                my_log( LOG_ERR, errno, "failed to detach daemon" );
+            if (close(0) < 0 || close(1) < 0 || close(2) < 0 || open("/dev/null", 0) != 0 || dup2(0, 1) < 0 ||
+                dup2(0, 2) < 0 || setpgid(0, 0) < 0) {
+                my_log(LOG_ERR, errno, "failed to detach daemon");
             }
         }
 
@@ -147,7 +144,7 @@ int main( int ArgCn, char *ArgVc[] ) {
         // Clean up
         igmpProxyCleanUp();
 
-    } while ( false );
+    } while (false);
 
     // Inform that we are exiting.
     my_log(LOG_INFO, 0, "Shutdown complete....");
@@ -163,7 +160,7 @@ int igmpProxyInit(void) {
     int Err;
 
     sa.sa_handler = signalHandler;
-    sa.sa_flags = 0;    /* Interrupt system calls */
+    sa.sa_flags = 0; /* Interrupt system calls */
     sigemptyset(&sa.sa_mask);
     sigaction(SIGTERM, &sa, NULL);
     sigaction(SIGINT, &sa, NULL);
@@ -174,10 +171,14 @@ int igmpProxyInit(void) {
     // Configures IF states and settings
     configureVifs();
 
-    switch ( Err = enableMRouter() ) {
-    case 0: break;
-    case EADDRINUSE: my_log( LOG_ERR, EADDRINUSE, "MC-Router API already in use" ); break;
-    default: my_log( LOG_ERR, Err, "MRT_INIT failed" );
+    switch (Err = enableMRouter()) {
+    case 0:
+        break;
+    case EADDRINUSE:
+        my_log(LOG_ERR, EADDRINUSE, "MC-Router API already in use");
+        break;
+    default:
+        my_log(LOG_ERR, Err, "MRT_INIT failed");
     }
 
     /* create VIFs for all IP, non-loop interfaces
@@ -185,37 +186,36 @@ int igmpProxyInit(void) {
     {
         unsigned Ix;
         struct IfDesc *Dp;
-        int     vifcount = 0, upsvifcount = 0;
+        int vifcount = 0, upsvifcount = 0;
 
         // init array to "not set"
-        for ( Ix = 0; Ix < MAX_UPS_VIFS; Ix++)
-        {
+        for (Ix = 0; Ix < MAX_UPS_VIFS; Ix++) {
             upStreamIfIdx[Ix] = -1;
         }
 
-        for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) {
+        for (Ix = 0; (Dp = getIfByIx(Ix)); Ix++) {
 
-            if ( Dp->InAdr.s_addr && ! (Dp->Flags & IFF_LOOPBACK) ) {
-                if(Dp->state == IF_STATE_UPSTREAM) {
-                    if (upsvifcount < MAX_UPS_VIFS -1)
-                    {
-                        my_log(LOG_DEBUG, 0, "Found upstrem IF #%d, will assing as upstream Vif %d",
-                            upsvifcount, Ix);
+            if (Dp->InAdr.s_addr && !(Dp->Flags & IFF_LOOPBACK)) {
+                if (Dp->state == IF_STATE_UPSTREAM) {
+                    if (upsvifcount < MAX_UPS_VIFS - 1) {
+                        my_log(LOG_DEBUG, 0, "Found upstrem IF #%d, will assing as upstream Vif %d", upsvifcount, Ix);
                         upStreamIfIdx[upsvifcount++] = Ix;
                     } else {
-                        my_log(LOG_ERR, 0, "Cannot set VIF #%d as upstream as well. Mac upstream Vif count is %d",
-                            Ix, MAX_UPS_VIFS);
+                        my_log(LOG_ERR, 0,
+                               "Cannot set VIF #%d as upstream as well. Mac "
+                               "upstream Vif count is %d",
+                               Ix, MAX_UPS_VIFS);
                     }
                 }
 
                 if (Dp->state != IF_STATE_DISABLED) {
-                    addVIF( Dp );
+                    addVIF(Dp);
                     vifcount++;
                 }
             }
         }
 
-        if(0 == upsvifcount) {
+        if (0 == upsvifcount) {
             my_log(LOG_ERR, 0, "There must be at least 1 Vif as upstream.");
         }
     }
@@ -234,11 +234,11 @@ int igmpProxyInit(void) {
 *   Clean up all on exit...
 */
 void igmpProxyCleanUp(void) {
-    my_log( LOG_DEBUG, 0, "clean handler called" );
+    my_log(LOG_DEBUG, 0, "clean handler called");
 
-    free_all_callouts();    // No more timeouts.
-    clearAllRoutes();       // Remove all routes.
-    disableMRouter();       // Disable the multirout API
+    free_all_callouts(); // No more timeouts.
+    clearAllRoutes();    // Remove all routes.
+    disableMRouter();    // Disable the multirout API
 }
 
 /**
@@ -249,12 +249,12 @@ void igmpProxyRun(void) {
     struct Config *config = getCommonConfig();
     // Set some needed values.
     register int recvlen;
-    int     MaxFD, Rt, secs;
-    fd_set  ReadFDS;
+    int MaxFD, Rt, secs;
+    fd_set ReadFDS;
     socklen_t dummy = 0;
-    struct  timespec  curtime, lasttime, difftime, tv;
+    struct timespec curtime, lasttime, difftime, tv;
     // The timeout is a pointer in order to set it to NULL if nessecary.
-    struct  timespec  *timeout = &tv;
+    struct timespec *timeout = &tv;
 
     // Initialize timer vars
     difftime.tv_nsec = 0;
@@ -282,7 +282,7 @@ void igmpProxyRun(void) {
 
         // Prepare timeout...
         secs = timer_nextTimer();
-        if(secs == -1) {
+        if (secs == -1) {
             timeout = NULL;
         } else {
             timeout->tv_nsec = 0;
@@ -292,26 +292,25 @@ void igmpProxyRun(void) {
         // Prepare for select.
         MaxFD = MRouterFD;
 
-        FD_ZERO( &ReadFDS );
-        FD_SET( MRouterFD, &ReadFDS );
+        FD_ZERO(&ReadFDS);
+        FD_SET(MRouterFD, &ReadFDS);
 
         // wait for input
-        Rt = pselect( MaxFD +1, &ReadFDS, NULL, NULL, timeout, NULL );
+        Rt = pselect(MaxFD + 1, &ReadFDS, NULL, NULL, timeout, NULL);
 
         // log and ignore failures
-        if( Rt < 0 ) {
-            my_log( LOG_WARNING, errno, "select() failure" );
+        if (Rt < 0) {
+            my_log(LOG_WARNING, errno, "select() failure");
             continue;
-        }
-        else if( Rt > 0 ) {
+        } else if (Rt > 0) {
 
             // Read IGMP request, and handle it...
-            if( FD_ISSET( MRouterFD, &ReadFDS ) ) {
+            if (FD_ISSET(MRouterFD, &ReadFDS)) {
 
-                recvlen = recvfrom(MRouterFD, recv_buf, RECV_BUF_SIZE,
-                                   0, NULL, &dummy);
+                recvlen = recvfrom(MRouterFD, recv_buf, RECV_BUF_SIZE, 0, NULL, &dummy);
                 if (recvlen < 0) {
-                    if (errno != EINTR) my_log(LOG_ERR, errno, "recvfrom");
+                    if (errno != EINTR)
+                        my_log(LOG_ERR, errno, "recvfrom");
                     continue;
                 }
 
@@ -348,9 +347,7 @@ void igmpProxyRun(void) {
                 age_callout_queue(difftime.tv_sec);
             secs = -1;
         } while (difftime.tv_sec > 0);
-
     }
-
 }
 
 /*

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -36,51 +36,50 @@
 */
 
 #include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <syslog.h>
-#include <signal.h>
-#include <unistd.h>
 #include <string.h>
-#include <fcntl.h>
-#include <stdbool.h>
+#include <syslog.h>
 #include <time.h>
+#include <unistd.h>
 
-#include <sys/socket.h>
-#include <sys/un.h>
 #include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 
+#include <arpa/inet.h>
 #include <net/if.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
 
-#include "os.h"
 #include "config.h"
+#include "os.h"
 
 /*
  * Limit on length of route data
  */
-#define MAX_IP_PACKET_LEN	576
-#define MIN_IP_HEADER_LEN	20
-#define MAX_IP_HEADER_LEN	60
-#define IP_HEADER_RAOPT_LEN	24
+#define MAX_IP_PACKET_LEN 576
+#define MIN_IP_HEADER_LEN 20
+#define MAX_IP_HEADER_LEN 60
+#define IP_HEADER_RAOPT_LEN 24
 
-#define MAX_MC_VIFS    32     // !!! check this const in the specific includes
-#define MAX_UPS_VIFS    8
+#define MAX_MC_VIFS 32 // !!! check this const in the specific includes
+#define MAX_UPS_VIFS 8
 
 // Useful macros..
-#define VCMC( Vc )  (sizeof( Vc ) / sizeof( (Vc)[ 0 ] ))
-#define VCEP( Vc )  (&(Vc)[ VCMC( Vc ) ])
+#define VCMC(Vc) (sizeof(Vc) / sizeof((Vc)[0]))
+#define VCEP(Vc) (&(Vc)[VCMC(Vc)])
 
 // Bit manipulation macros...
-#define BIT_ZERO(X)      ((X) = 0)
-#define BIT_SET(X,n)     ((X) |= 1 << (n))
-#define BIT_CLR(X,n)     ((X) &= ~(1 << (n)))
-#define BIT_TST(X,n)     ((X) & 1 << (n))
-
+#define BIT_ZERO(X) ((X) = 0)
+#define BIT_SET(X, n) ((X) |= 1 << (n))
+#define BIT_CLR(X, n) ((X) &= ~(1 << (n)))
+#define BIT_TST(X, n) ((X)&1 << (n))
 
 //#################################################################################
 //  Globals
@@ -90,15 +89,13 @@
  * External declarations for global variables and functions.
  */
 #define RECV_BUF_SIZE 8192
-extern char     *recv_buf;
-extern char     *send_buf;
+extern char *recv_buf;
+extern char *send_buf;
 
-extern char     s1[];
-extern char     s2[];
-extern char		s3[];
-extern char		s4[];
-
-
+extern char s1[];
+extern char s2[];
+extern char s3[];
+extern char s4[];
 
 //#################################################################################
 //  Lib function prototypes.
@@ -106,77 +103,75 @@ extern char		s4[];
 
 /* syslog.c
  */
-extern bool Log2Stderr;           // Log to stderr instead of to syslog
-extern int  LogLevel;             // Log threshold, LOG_WARNING .... LOG_DEBUG
+extern bool Log2Stderr; // Log to stderr instead of to syslog
+extern int LogLevel;    // Log threshold, LOG_WARNING .... LOG_DEBUG
 
-void my_log( int Serverity, int Errno, const char *FmtSt, ... );
+void my_log(int Serverity, int Errno, const char *FmtSt, ...);
 
 /* ifvc.c
  */
-#define MAX_IF         40     // max. number of interfaces recognized
+#define MAX_IF 40 // max. number of interfaces recognized
 
 // Interface states
-#define IF_STATE_DISABLED      0   // Interface should be ignored.
-#define IF_STATE_UPSTREAM      1   // Interface is the upstream interface
-#define IF_STATE_DOWNSTREAM    2   // Interface is a downstream interface
-#define IF_STATE_LOST          3   // aimwang: Temp from downstream to hidden
-#define IF_STATE_HIDDEN        4   // aimwang: Interface is hidden
+#define IF_STATE_DISABLED 0   // Interface should be ignored.
+#define IF_STATE_UPSTREAM 1   // Interface is the upstream interface
+#define IF_STATE_DOWNSTREAM 2 // Interface is a downstream interface
+#define IF_STATE_LOST 3       // aimwang: Temp from downstream to hidden
+#define IF_STATE_HIDDEN 4     // aimwang: Interface is hidden
 
 // Multicast default values...
-#define DEFAULT_ROBUSTNESS     2
-#define DEFAULT_THRESHOLD      1
-#define DEFAULT_RATELIMIT      0
+#define DEFAULT_ROBUSTNESS 2
+#define DEFAULT_THRESHOLD 1
+#define DEFAULT_RATELIMIT 0
 
 // Define timer constants (in seconds...)
-#define INTERVAL_QUERY          125
-#define INTERVAL_QUERY_RESPONSE  10
+#define INTERVAL_QUERY 125
+#define INTERVAL_QUERY_RESPONSE 10
 //#define INTERVAL_QUERY_RESPONSE  10
 
-#define ROUTESTATE_NOTJOINED            0   // The group corresponding to route is not joined
-#define ROUTESTATE_JOINED               1   // The group corresponding to route is joined
-#define ROUTESTATE_CHECK_LAST_MEMBER    2   // The router is checking for hosts
-
-
+#define ROUTESTATE_NOTJOINED 0         // The group corresponding to route is not joined
+#define ROUTESTATE_JOINED 1            // The group corresponding to route is joined
+#define ROUTESTATE_CHECK_LAST_MEMBER 2 // The router is checking for hosts
 
 // Linked list of networks...
 struct SubnetList {
-    uint32_t            subnet_addr;
-    uint32_t            subnet_mask;
-    struct SubnetList   *next;
+    uint32_t subnet_addr;
+    uint32_t subnet_mask;
+    struct SubnetList *next;
 };
 
 struct IfDesc {
-    char                Name[IF_NAMESIZE];
-    struct in_addr      InAdr;          /* == 0 for non IP interfaces */
-    short               Flags;
-    short               state;
-    struct SubnetList*  allowednets;
-    struct SubnetList*  allowedgroups;
-    unsigned int        robustness;
-    unsigned char       threshold;   /* ttl limit */
-    unsigned int        ratelimit;
-    unsigned int        index;
+    char Name[IF_NAMESIZE];
+    struct in_addr InAdr; /* == 0 for non IP interfaces */
+    short Flags;
+    short state;
+    struct SubnetList *allowednets;
+    struct SubnetList *allowedgroups;
+    unsigned int robustness;
+    unsigned char threshold; /* ttl limit */
+    unsigned int ratelimit;
+    unsigned int index;
 };
 
 // Keeps common configuration settings
 struct Config {
-    unsigned int        robustnessValue;
-    unsigned int        queryInterval;
-    unsigned int        queryResponseInterval;
+    unsigned int robustnessValue;
+    unsigned int queryInterval;
+    unsigned int queryResponseInterval;
     // Used on startup..
-    unsigned int        startupQueryInterval;
-    unsigned int        startupQueryCount;
+    unsigned int startupQueryInterval;
+    unsigned int startupQueryCount;
     // Last member probe...
-    unsigned int        lastMemberQueryInterval;
-    unsigned int        lastMemberQueryCount;
+    unsigned int lastMemberQueryInterval;
+    unsigned int lastMemberQueryCount;
     // Set if upstream leave messages should be sent instantly..
-    unsigned short      fastUpstreamLeave;
+    unsigned short fastUpstreamLeave;
     //~ aimwang added
     // Set if nneed to detect new interface.
-    unsigned short	rescanVif;
+    unsigned short rescanVif;
     // Set if not detect new interface for down stream.
-    unsigned short	defaultInterfaceState;	// 0: disable, 2: downstream
-    //~ aimwang added done
+    unsigned short defaultInterfaceState; // 0: disable, 2: downstream
+                                          //~ aimwang added done
 };
 
 // Holds the indeces of the upstream IF...
@@ -184,33 +179,33 @@ extern int upStreamIfIdx[MAX_UPS_VIFS];
 
 /* ifvc.c
  */
-void rebuildIfVc( void );
-void buildIfVc( void );
-struct IfDesc *getIfByName( const char *IfName );
-struct IfDesc *getIfByIx( unsigned Ix );
-struct IfDesc *getIfByAddress( uint32_t Ix );
-struct IfDesc *getIfByVifIndex( unsigned vifindex );
-int isAdressValidForIf(struct IfDesc* intrface, uint32_t ipaddr);
+void rebuildIfVc(void);
+void buildIfVc(void);
+struct IfDesc *getIfByName(const char *IfName);
+struct IfDesc *getIfByIx(unsigned Ix);
+struct IfDesc *getIfByAddress(uint32_t Ix);
+struct IfDesc *getIfByVifIndex(unsigned vifindex);
+int isAdressValidForIf(struct IfDesc *intrface, uint32_t ipaddr);
 
 /* mroute-api.c
  */
 struct MRouteDesc {
-    struct in_addr  OriginAdr, McAdr;
-    short           InVif;
-    uint8_t           TtlVc[ MAX_MC_VIFS ];
+    struct in_addr OriginAdr, McAdr;
+    short InVif;
+    uint8_t TtlVc[MAX_MC_VIFS];
 };
 
 // IGMP socket as interface for the mrouted API
 // - receives the IGMP messages
 extern int MRouterFD;
 
-int enableMRouter( void );
-void disableMRouter( void );
-void addVIF( struct IfDesc *Dp );
-void delVIF( struct IfDesc *Dp );
-int addMRoute( struct MRouteDesc * Dp );
-int delMRoute( struct MRouteDesc * Dp );
-int getVifIx( struct IfDesc *IfDp );
+int enableMRouter(void);
+void disableMRouter(void);
+void addVIF(struct IfDesc *Dp);
+void delVIF(struct IfDesc *Dp);
+int addMRoute(struct MRouteDesc *Dp);
+int delMRoute(struct MRouteDesc *Dp);
+int getVifIx(struct IfDesc *IfDp);
 
 /* config.c
  */
@@ -225,13 +220,13 @@ extern uint32_t allrouters_group;
 extern uint32_t alligmp3_group;
 void initIgmp(void);
 void acceptIgmp(int);
-void sendIgmp (uint32_t, uint32_t, int, int, uint32_t,int);
+void sendIgmp(uint32_t, uint32_t, int, int, uint32_t, int);
 
 /* lib.c
  */
-char   *fmtInAdr( char *St, struct in_addr InAdr );
-char   *inetFmt(uint32_t addr, char *s);
-char   *inetFmts(uint32_t addr, uint32_t mask, char *s);
+char *fmtInAdr(char *St, struct in_addr InAdr);
+char *inetFmt(uint32_t addr, char *s);
+char *inetFmts(uint32_t addr, uint32_t mask, char *s);
 uint16_t inetChksum(uint16_t *addr, int len);
 
 /* kern.c
@@ -248,13 +243,12 @@ void k_leave(uint32_t grp, uint32_t ifa);
 
 /* udpsock.c
  */
-int openUdpSocket( uint32_t PeerInAdr, uint16_t PeerPort );
+int openUdpSocket(uint32_t PeerInAdr, uint16_t PeerPort);
 
 /* mcgroup.c
  */
-int joinMcGroup( int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr );
-int leaveMcGroup( int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr );
-
+int joinMcGroup(int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr);
+int leaveMcGroup(int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr);
 
 /* rttable.c
  */
@@ -274,7 +268,7 @@ void acceptGroupReport(uint32_t src, uint32_t group);
 void acceptLeaveMessage(uint32_t src, uint32_t group);
 void sendGeneralMembershipQuery(void);
 
-/* callout.c 
+/* callout.c
 */
 typedef void (*timer_f)(void *);
 
@@ -288,9 +282,9 @@ int timer_leftTimer(int);
 
 /* confread.c
  */
-#define MAX_TOKEN_LENGTH    30
+#define MAX_TOKEN_LENGTH 30
 
 int openConfigFile(char *filename);
 void closeConfigFile(void);
-char* nextConfigToken(void);
-char* getCurrentConfigToken(void);
+char *nextConfigToken(void);
+char *getCurrentConfigToken(void);

--- a/src/igmpv3.h
+++ b/src/igmpv3.h
@@ -38,8 +38,8 @@ struct igmpv3_report {
     struct igmpv3_grec igmp_grec[0];
 };
 
-#define IGMPV3_MODE_IS_INCLUDE   1
-#define IGMPV3_MODE_IS_EXCLUDE   2
+#define IGMPV3_MODE_IS_INCLUDE 1
+#define IGMPV3_MODE_IS_EXCLUDE 2
 #define IGMPV3_CHANGE_TO_INCLUDE 3
 #define IGMPV3_CHANGE_TO_EXCLUDE 4
 #define IGMPV3_ALLOW_NEW_SOURCES 5

--- a/src/kern.c
+++ b/src/kern.c
@@ -32,7 +32,6 @@
 **
 */
 
-
 #include "igmpproxy.h"
 
 int curttl = 0;
@@ -47,16 +46,14 @@ void k_set_rcvbuf(int bufsize, int minsize) {
      * value.  The highest acceptable value being smaller than
      * minsize is a fatal error.
      */
-    if (setsockopt(MRouterFD, SOL_SOCKET, SO_RCVBUF,
-                   (char *)&bufsize, sizeof(bufsize)) < 0) {
+    if (setsockopt(MRouterFD, SOL_SOCKET, SO_RCVBUF, (char *)&bufsize, sizeof(bufsize)) < 0) {
         bufsize -= delta;
         while (1) {
             iter++;
             if (delta > 1)
                 delta /= 2;
 
-            if (setsockopt(MRouterFD, SOL_SOCKET, SO_RCVBUF,
-                           (char *)&bufsize, sizeof(bufsize)) < 0) {
+            if (setsockopt(MRouterFD, SOL_SOCKET, SO_RCVBUF, (char *)&bufsize, sizeof(bufsize)) < 0) {
                 bufsize -= delta;
             } else {
                 if (delta < 1024)
@@ -65,8 +62,7 @@ void k_set_rcvbuf(int bufsize, int minsize) {
             }
         }
         if (bufsize < minsize) {
-            my_log(LOG_ERR, 0, "OS-allowed buffer size %u < app min %u",
-                bufsize, minsize);
+            my_log(LOG_ERR, 0, "OS-allowed buffer size %u < app min %u", bufsize, minsize);
             /*NOTREACHED*/
         }
     }
@@ -74,19 +70,16 @@ void k_set_rcvbuf(int bufsize, int minsize) {
 }
 
 void k_hdr_include(int hdrincl) {
-    if (setsockopt(MRouterFD, IPPROTO_IP, IP_HDRINCL,
-                   (char *)&hdrincl, sizeof(hdrincl)) < 0)
+    if (setsockopt(MRouterFD, IPPROTO_IP, IP_HDRINCL, (char *)&hdrincl, sizeof(hdrincl)) < 0)
         my_log(LOG_WARNING, errno, "setsockopt IP_HDRINCL %u", hdrincl);
 }
-
 
 void k_set_ttl(int t) {
 #ifndef RAW_OUTPUT_IS_RAW
     unsigned char ttl;
 
     ttl = t;
-    if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_TTL,
-                   (char *)&ttl, sizeof(ttl)) < 0)
+    if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_TTL, (char *)&ttl, sizeof(ttl)) < 0)
         my_log(LOG_WARNING, errno, "setsockopt IP_MULTICAST_TTL %u", ttl);
 #endif
     curttl = t;
@@ -96,8 +89,7 @@ void k_set_loop(int l) {
     unsigned char loop;
 
     loop = l;
-    if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_LOOP,
-                   (char *)&loop, sizeof(loop)) < 0)
+    if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_LOOP, (char *)&loop, sizeof(loop)) < 0)
         my_log(LOG_WARNING, errno, "setsockopt IP_MULTICAST_LOOP %u", loop);
 }
 
@@ -105,10 +97,8 @@ void k_set_if(uint32_t ifa) {
     struct in_addr adr;
 
     adr.s_addr = ifa;
-    if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_IF,
-                   (char *)&adr, sizeof(adr)) < 0)
-        my_log(LOG_WARNING, errno, "setsockopt IP_MULTICAST_IF %s",
-            inetFmt(ifa, s1));
+    if (setsockopt(MRouterFD, IPPROTO_IP, IP_MULTICAST_IF, (char *)&adr, sizeof(adr)) < 0)
+        my_log(LOG_WARNING, errno, "setsockopt IP_MULTICAST_IF %s", inetFmt(ifa, s1));
 }
 
 /*

--- a/src/lib.c
+++ b/src/lib.c
@@ -37,9 +37,9 @@
 /*
  * Exported variables.
  */
-char s1[19];        /* buffers to hold the string representations  */
-char s2[19];        /* of IP addresses, to be passed to inet_fmt() */
-char s3[19];        /* or inet_fmts().                             */
+char s1[19]; /* buffers to hold the string representations  */
+char s2[19]; /* of IP addresses, to be passed to inet_fmt() */
+char s3[19]; /* or inet_fmts().                             */
 char s4[19];
 
 /*
@@ -48,12 +48,9 @@ char s4[19];
 ** returns: - pointer to 'St'
 **
 */
-char *fmtInAdr( char *St, struct in_addr InAdr ) {
-    sprintf( St, "%u.%u.%u.%u",
-             ((uint8_t *)&InAdr.s_addr)[ 0 ],
-             ((uint8_t *)&InAdr.s_addr)[ 1 ],
-             ((uint8_t *)&InAdr.s_addr)[ 2 ],
-             ((uint8_t *)&InAdr.s_addr)[ 3 ] );
+char *fmtInAdr(char *St, struct in_addr InAdr) {
+    sprintf(St, "%u.%u.%u.%u", ((uint8_t *)&InAdr.s_addr)[0], ((uint8_t *)&InAdr.s_addr)[1],
+            ((uint8_t *)&InAdr.s_addr)[2], ((uint8_t *)&InAdr.s_addr)[3]);
 
     return St;
 }
@@ -66,7 +63,7 @@ char *inetFmt(uint32_t addr, char *s) {
 
     a = (unsigned char *)&addr;
     sprintf(s, "%u.%u.%u.%u", a[0], a[1], a[2], a[3]);
-    return(s);
+    return (s);
 }
 
 /*
@@ -79,19 +76,22 @@ char *inetFmts(uint32_t addr, uint32_t mask, char *s) {
 
     if ((addr == 0) && (mask == 0)) {
         sprintf(s, "default");
-        return(s);
+        return (s);
     }
     a = (unsigned char *)&addr;
     m = (unsigned char *)&mask;
     bits = 33 - ffs(ntohl(mask));
 
-    if (m[3] != 0) sprintf(s, "%u.%u.%u.%u/%d", a[0], a[1], a[2], a[3],
-                           bits);
-    else if (m[2] != 0) sprintf(s, "%u.%u.%u/%d",    a[0], a[1], a[2], bits);
-    else if (m[1] != 0) sprintf(s, "%u.%u/%d",       a[0], a[1], bits);
-    else                sprintf(s, "%u/%d",          a[0], bits);
+    if (m[3] != 0)
+        sprintf(s, "%u.%u.%u.%u/%d", a[0], a[1], a[2], a[3], bits);
+    else if (m[2] != 0)
+        sprintf(s, "%u.%u.%u/%d", a[0], a[1], a[2], bits);
+    else if (m[1] != 0)
+        sprintf(s, "%u.%u/%d", a[0], a[1], bits);
+    else
+        sprintf(s, "%u/%d", a[0], bits);
 
-    return(s);
+    return (s);
 }
 
 /*
@@ -131,7 +131,7 @@ uint16_t inetChksum(uint16_t *addr, int len) {
 
     /* mop up an odd byte, if necessary */
     if (nleft == 1) {
-        *(uint8_t *) (&answer) = *(uint8_t *)w ;
+        *(uint8_t *)(&answer) = *(uint8_t *)w;
         sum += answer;
     }
 
@@ -141,5 +141,5 @@ uint16_t inetChksum(uint16_t *addr, int len) {
     sum = (sum >> 16) + (sum & 0xffff); /* add hi 16 to low 16 */
     sum += (sum >> 16);                 /* add carry */
     answer = ~sum;                      /* truncate to 16 bits */
-    return(answer);
+    return (answer);
 }

--- a/src/mcgroup.c
+++ b/src/mcgroup.c
@@ -38,11 +38,10 @@
 
 #include "igmpproxy.h"
 
-
-/**
-*   Common function for joining or leaving a MCast group.
-*/
-static int joinleave( int Cmd, int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr ) {
+/*******************************************************************************
+ * Common function for joining or leaving a MCast group.
+ ******************************************************************************/
+static int joinleave(int Cmd, int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr) {
     struct ip_mreq CtlReq;
     const char *CmdSt = Cmd == 'j' ? "join" : "leave";
 
@@ -50,38 +49,33 @@ static int joinleave( int Cmd, int UdpSock, struct IfDesc *IfDp, uint32_t mcasta
     CtlReq.imr_multiaddr.s_addr = mcastaddr;
     CtlReq.imr_interface.s_addr = IfDp->InAdr.s_addr;
 
-    {
-        my_log( LOG_NOTICE, 0, "%sMcGroup: %s on %s", CmdSt,
-            inetFmt( mcastaddr, s1 ), IfDp ? IfDp->Name : "<any>" );
-    }
+    { my_log(LOG_NOTICE, 0, "%sMcGroup: %s on %s", CmdSt, inetFmt(mcastaddr, s1), IfDp ? IfDp->Name : "<any>"); }
 
-    if( setsockopt( UdpSock, IPPROTO_IP,
-          Cmd == 'j' ? IP_ADD_MEMBERSHIP : IP_DROP_MEMBERSHIP,
-          (void *)&CtlReq, sizeof( CtlReq ) ) )
-    {
-        my_log( LOG_WARNING, errno, "MRT_%s_MEMBERSHIP failed", Cmd == 'j' ? "ADD" : "DROP" );
+    if (setsockopt(UdpSock, IPPROTO_IP, Cmd == 'j' ? IP_ADD_MEMBERSHIP : IP_DROP_MEMBERSHIP, (void *)&CtlReq,
+                   sizeof(CtlReq))) {
+        my_log(LOG_WARNING, errno, "MRT_%s_MEMBERSHIP failed", Cmd == 'j' ? "ADD" : "DROP");
         return 1;
     }
 
     return 0;
 }
 
-/**
-*   Joins the MC group with the address 'McAdr' on the interface 'IfName'.
-*   The join is bound to the UDP socket 'UdpSock', so if this socket is
-*   closed the membership is dropped.
-*
-*   @return 0 if the function succeeds, 1 if parameters are wrong or the join fails
-*/
-int joinMcGroup( int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr ) {
-    return joinleave( 'j', UdpSock, IfDp, mcastaddr );
+/*******************************************************************************
+ * Joins the MC group with the address 'McAdr' on the interface 'IfName'.
+ * The join is bound to the UDP socket 'UdpSock', so if this socket is closed
+ *  the membership is dropped.
+ *
+ * @return 0 if function succeeds, 1 if parameters are wrong or join fails
+******************************************************************************/
+int joinMcGroup(int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr) {
+    return joinleave('j', UdpSock, IfDp, mcastaddr);
 }
 
-/**
-*   Leaves the MC group with the address 'McAdr' on the interface 'IfName'.
-*
-*   @return 0 if the function succeeds, 1 if parameters are wrong or the join fails
-*/
-int leaveMcGroup( int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr ) {
-    return joinleave( 'l', UdpSock, IfDp, mcastaddr );
+/*******************************************************************************
+ * Leaves the MC group with the address 'McAdr' on the interface 'IfName'.
+ *
+ * @return 0 if function succeeds, 1 if parameters are wrong or join fails
+ ******************************************************************************/
+int leaveMcGroup(int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr) {
+    return joinleave('l', UdpSock, IfDp, mcastaddr);
 }

--- a/src/mroute-api.c
+++ b/src/mroute-api.c
@@ -37,25 +37,21 @@
 *   This module contains the interface routines to the Linux mrouted API
 */
 
-
 #include "igmpproxy.h"
 
 // MAX_MC_VIFS from mclab.h must have same value as MAXVIFS from mroute.h
 #if MAX_MC_VIFS != MAXVIFS
-# error "constants don't match, correct mclab.h"
+#error "constants don't match, correct mclab.h"
 #endif
 
 // need an IGMP socket as interface for the mrouted API
 // - receives the IGMP messages
-int         MRouterFD;          /* socket for all network I/O  */
-char        *recv_buf;          /* input packet buffer         */
-char        *send_buf;          /* output packet buffer        */
-
+int MRouterFD;  /* socket for all network I/O  */
+char *recv_buf; /* input packet buffer         */
+char *send_buf; /* output packet buffer        */
 
 // my internal virtual interfaces descriptor vector
-static struct VifDesc {
-    struct IfDesc *IfDp;
-} VifDescVc[ MAXVIFS ];
+static struct VifDesc { struct IfDesc *IfDp; } VifDescVc[MAXVIFS];
 
 /*
 ** Initialises the mrouted API and locks it by this exclusively.
@@ -63,15 +59,13 @@ static struct VifDesc {
 ** returns: - 0 if the functions succeeds
 **          - the errno value for non-fatal failure condition
 */
-int enableMRouter(void)
-{
+int enableMRouter(void) {
     int Va = 1;
 
-    if ( (MRouterFD  = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP)) < 0 )
-        my_log( LOG_ERR, errno, "IGMP socket open" );
+    if ((MRouterFD = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP)) < 0)
+        my_log(LOG_ERR, errno, "IGMP socket open");
 
-    if ( setsockopt( MRouterFD, IPPROTO_IP, MRT_INIT,
-                     (void *)&Va, sizeof( Va ) ) )
+    if (setsockopt(MRouterFD, IPPROTO_IP, MRT_INIT, (void *)&Va, sizeof(Va)))
         return errno;
 
     return 0;
@@ -81,13 +75,10 @@ int enableMRouter(void)
 ** Diable the mrouted API and relases by this the lock.
 **
 */
-void disableMRouter(void)
-{
-    if ( setsockopt( MRouterFD, IPPROTO_IP, MRT_DONE, NULL, 0 )
-         || close( MRouterFD )
-    ) {
+void disableMRouter(void) {
+    if (setsockopt(MRouterFD, IPPROTO_IP, MRT_DONE, NULL, 0) || close(MRouterFD)) {
         MRouterFD = 0;
-        my_log( LOG_ERR, errno, "MRT_DONE/close" );
+        my_log(LOG_ERR, errno, "MRT_DONE/close");
     }
 
     MRouterFD = 0;
@@ -96,8 +87,7 @@ void disableMRouter(void)
 /*
  * aimwang: delVIF()
  */
-void delVIF( struct IfDesc *IfDp )
-{
+void delVIF(struct IfDesc *IfDp) {
     struct vifctl VifCtl;
 
     if (-1 == IfDp->index)
@@ -105,41 +95,39 @@ void delVIF( struct IfDesc *IfDp )
 
     VifCtl.vifc_vifi = IfDp->index;
 
-    my_log( LOG_NOTICE, 0, "removing VIF, Ix %d Fl 0x%x IP 0x%08x %s, Threshold: %d, Ratelimit: %d",
-         IfDp->index, IfDp->Flags, IfDp->InAdr.s_addr, IfDp->Name, IfDp->threshold, IfDp->ratelimit);
+    my_log(LOG_NOTICE, 0, "removing VIF, Ix %d Fl 0x%x IP 0x%08x %s, Threshold: %d, Ratelimit: %d", IfDp->index,
+           IfDp->Flags, IfDp->InAdr.s_addr, IfDp->Name, IfDp->threshold, IfDp->ratelimit);
 
-    if ( setsockopt( MRouterFD, IPPROTO_IP, MRT_DEL_VIF,
-                     (char *)&VifCtl, sizeof( VifCtl ) ) )
-        my_log( LOG_WARNING, errno, "MRT_DEL_VIF" );
+    if (setsockopt(MRouterFD, IPPROTO_IP, MRT_DEL_VIF, (char *)&VifCtl, sizeof(VifCtl)))
+        my_log(LOG_WARNING, errno, "MRT_DEL_VIF");
 }
 
 /*
 ** Adds the interface '*IfDp' as virtual interface to the mrouted API
 **
 */
-void addVIF( struct IfDesc *IfDp )
-{
+void addVIF(struct IfDesc *IfDp) {
     struct vifctl VifCtl;
     struct VifDesc *VifDp;
 
     /* search free (aimwang: or exist) VifDesc
      */
-    for ( VifDp = VifDescVc; VifDp < VCEP( VifDescVc ); VifDp++ ) {
-        if ( ! VifDp->IfDp || VifDp->IfDp == IfDp)
+    for (VifDp = VifDescVc; VifDp < VCEP(VifDescVc); VifDp++) {
+        if (!VifDp->IfDp || VifDp->IfDp == IfDp)
             break;
     }
 
     /* no more space
      */
-    if ( VifDp >= VCEP( VifDescVc ) )
-        my_log( LOG_ERR, ENOMEM, "addVIF, out of VIF space" );
+    if (VifDp >= VCEP(VifDescVc))
+        my_log(LOG_ERR, ENOMEM, "addVIF, out of VIF space");
 
     VifDp->IfDp = IfDp;
 
-    VifCtl.vifc_vifi  = VifDp - VifDescVc;
-    VifCtl.vifc_flags = 0;        /* no tunnel, no source routing, register ? */
-    VifCtl.vifc_threshold  = VifDp->IfDp->threshold;    // Packet TTL must be at least 1 to pass them
-    VifCtl.vifc_rate_limit = VifDp->IfDp->ratelimit;    // Ratelimit
+    VifCtl.vifc_vifi = VifDp - VifDescVc;
+    VifCtl.vifc_flags = 0;                           /* no tunnel, no source routing, register ? */
+    VifCtl.vifc_threshold = VifDp->IfDp->threshold;  // Packet TTL must be at least 1 to pass them
+    VifCtl.vifc_rate_limit = VifDp->IfDp->ratelimit; // Ratelimit
 
     VifCtl.vifc_lcl_addr.s_addr = VifDp->IfDp->InAdr.s_addr;
     VifCtl.vifc_rmt_addr.s_addr = INADDR_ANY;
@@ -147,21 +135,18 @@ void addVIF( struct IfDesc *IfDp )
     // Set the index...
     VifDp->IfDp->index = VifCtl.vifc_vifi;
 
-    my_log( LOG_NOTICE, 0, "adding VIF, Ix %d Fl 0x%x IP 0x%08x %s, Threshold: %d, Ratelimit: %d",
-         VifCtl.vifc_vifi, VifCtl.vifc_flags,  VifCtl.vifc_lcl_addr.s_addr, VifDp->IfDp->Name,
-         VifCtl.vifc_threshold, VifCtl.vifc_rate_limit);
+    my_log(LOG_NOTICE, 0, "adding VIF, Ix %d Fl 0x%x IP 0x%08x %s, Threshold: %d, Ratelimit: %d", VifCtl.vifc_vifi,
+           VifCtl.vifc_flags, VifCtl.vifc_lcl_addr.s_addr, VifDp->IfDp->Name, VifCtl.vifc_threshold,
+           VifCtl.vifc_rate_limit);
 
     struct SubnetList *currSubnet;
-    for(currSubnet = IfDp->allowednets; currSubnet; currSubnet = currSubnet->next) {
-        my_log(LOG_DEBUG, 0, "        Network for [%s] : %s",
-            IfDp->Name,
-            inetFmts(currSubnet->subnet_addr, currSubnet->subnet_mask, s1));
+    for (currSubnet = IfDp->allowednets; currSubnet; currSubnet = currSubnet->next) {
+        my_log(LOG_DEBUG, 0, "        Network for [%s] : %s", IfDp->Name,
+               inetFmts(currSubnet->subnet_addr, currSubnet->subnet_mask, s1));
     }
 
-    if ( setsockopt( MRouterFD, IPPROTO_IP, MRT_ADD_VIF,
-                     (char *)&VifCtl, sizeof( VifCtl ) ) )
-        my_log( LOG_ERR, errno, "MRT_ADD_VIF" );
-
+    if (setsockopt(MRouterFD, IPPROTO_IP, MRT_ADD_VIF, (char *)&VifCtl, sizeof(VifCtl)))
+        my_log(LOG_ERR, errno, "MRT_ADD_VIF");
 }
 
 /*
@@ -170,34 +155,29 @@ void addVIF( struct IfDesc *IfDp )
 ** returns: - 0 if the function succeeds
 **          - the errno value for non-fatal failure condition
 */
-int addMRoute( struct MRouteDesc *Dp )
-{
+int addMRoute(struct MRouteDesc *Dp) {
     struct mfcctl CtlReq;
     int rc;
 
-    CtlReq.mfcc_origin    = Dp->OriginAdr;
-    CtlReq.mfcc_mcastgrp  = Dp->McAdr;
-    CtlReq.mfcc_parent    = Dp->InVif;
+    CtlReq.mfcc_origin = Dp->OriginAdr;
+    CtlReq.mfcc_mcastgrp = Dp->McAdr;
+    CtlReq.mfcc_parent = Dp->InVif;
 
     /* copy the TTL vector
      */
 
-    memcpy( CtlReq.mfcc_ttls, Dp->TtlVc, sizeof( CtlReq.mfcc_ttls ) );
+    memcpy(CtlReq.mfcc_ttls, Dp->TtlVc, sizeof(CtlReq.mfcc_ttls));
 
     {
-        char FmtBuO[ 32 ], FmtBuM[ 32 ];
+        char FmtBuO[32], FmtBuM[32];
 
-        my_log( LOG_NOTICE, 0, "Adding MFC: %s -> %s, InpVIf: %d",
-             fmtInAdr( FmtBuO, CtlReq.mfcc_origin ),
-             fmtInAdr( FmtBuM, CtlReq.mfcc_mcastgrp ),
-             (int)CtlReq.mfcc_parent
-           );
+        my_log(LOG_NOTICE, 0, "Adding MFC: %s -> %s, InpVIf: %d", fmtInAdr(FmtBuO, CtlReq.mfcc_origin),
+               fmtInAdr(FmtBuM, CtlReq.mfcc_mcastgrp), (int)CtlReq.mfcc_parent);
     }
 
-    rc = setsockopt( MRouterFD, IPPROTO_IP, MRT_ADD_MFC,
-                    (void *)&CtlReq, sizeof( CtlReq ) );
+    rc = setsockopt(MRouterFD, IPPROTO_IP, MRT_ADD_MFC, (void *)&CtlReq, sizeof(CtlReq));
     if (rc)
-        my_log( LOG_WARNING, errno, "MRT_ADD_MFC" );
+        my_log(LOG_WARNING, errno, "MRT_ADD_MFC");
 
     return rc;
 }
@@ -208,33 +188,28 @@ int addMRoute( struct MRouteDesc *Dp )
 ** returns: - 0 if the function succeeds
 **          - the errno value for non-fatal failure condition
 */
-int delMRoute( struct MRouteDesc *Dp )
-{
+int delMRoute(struct MRouteDesc *Dp) {
     struct mfcctl CtlReq;
     int rc;
 
-    CtlReq.mfcc_origin    = Dp->OriginAdr;
-    CtlReq.mfcc_mcastgrp  = Dp->McAdr;
-    CtlReq.mfcc_parent    = Dp->InVif;
+    CtlReq.mfcc_origin = Dp->OriginAdr;
+    CtlReq.mfcc_mcastgrp = Dp->McAdr;
+    CtlReq.mfcc_parent = Dp->InVif;
 
     /* clear the TTL vector
      */
-    memset( CtlReq.mfcc_ttls, 0, sizeof( CtlReq.mfcc_ttls ) );
+    memset(CtlReq.mfcc_ttls, 0, sizeof(CtlReq.mfcc_ttls));
 
     {
-        char FmtBuO[ 32 ], FmtBuM[ 32 ];
+        char FmtBuO[32], FmtBuM[32];
 
-        my_log( LOG_NOTICE, 0, "Removing MFC: %s -> %s, InpVIf: %d",
-             fmtInAdr( FmtBuO, CtlReq.mfcc_origin ),
-             fmtInAdr( FmtBuM, CtlReq.mfcc_mcastgrp ),
-             (int)CtlReq.mfcc_parent
-           );
+        my_log(LOG_NOTICE, 0, "Removing MFC: %s -> %s, InpVIf: %d", fmtInAdr(FmtBuO, CtlReq.mfcc_origin),
+               fmtInAdr(FmtBuM, CtlReq.mfcc_mcastgrp), (int)CtlReq.mfcc_parent);
     }
 
-    rc = setsockopt( MRouterFD, IPPROTO_IP, MRT_DEL_MFC,
-                    (void *)&CtlReq, sizeof( CtlReq ) );
+    rc = setsockopt(MRouterFD, IPPROTO_IP, MRT_DEL_MFC, (void *)&CtlReq, sizeof(CtlReq));
     if (rc)
-        my_log( LOG_WARNING, errno, "MRT_DEL_MFC" );
+        my_log(LOG_WARNING, errno, "MRT_DEL_MFC");
 
     return rc;
 }
@@ -246,12 +221,11 @@ int delMRoute( struct MRouteDesc *Dp )
 **          - -1 if no virtual interface exists for the interface
 **
 */
-int getVifIx( struct IfDesc *IfDp )
-{
+int getVifIx(struct IfDesc *IfDp) {
     struct VifDesc *Dp;
 
-    for ( Dp = VifDescVc; Dp < VCEP( VifDescVc ); Dp++ )
-        if ( Dp->IfDp == IfDp )
+    for (Dp = VifDescVc; Dp < VCEP(VifDescVc); Dp++)
+        if (Dp->IfDp == IfDp)
             return Dp - VifDescVc;
 
     return -1;

--- a/src/os-dragonfly.h
+++ b/src/os-dragonfly.h
@@ -1,18 +1,16 @@
-#include <net/route.h>
 #include <net/ip_mroute/ip_mroute.h>
-#include <netinet/ip.h>
+#include <net/route.h>
 #include <netinet/igmp.h>
+#include <netinet/ip.h>
 
 #define IGMP_V3_MEMBERSHIP_REPORT 0x22
 
-#define INADDR_ALLIGMPV3_GROUP ((in_addr_t) 0xe0000016)
+#define INADDR_ALLIGMPV3_GROUP ((in_addr_t)0xe0000016)
 
-static inline unsigned short ip_data_len(const struct ip *ip)
-{
+static inline unsigned short ip_data_len(const struct ip *ip) {
     return ip->ip_len;
 }
 
-static inline void ip_set_len(struct ip *ip, unsigned short len)
-{
+static inline void ip_set_len(struct ip *ip, unsigned short len) {
     ip->ip_len = len;
 }

--- a/src/os-freebsd.h
+++ b/src/os-freebsd.h
@@ -1,11 +1,10 @@
 #include <net/route.h>
-#include <netinet/in_systm.h>
-#include <netinet/ip_mroute.h>
-#include <netinet/ip.h>
 #include <netinet/igmp.h>
+#include <netinet/in_systm.h>
+#include <netinet/ip.h>
+#include <netinet/ip_mroute.h>
 
-#if __FreeBSD_version >= 800069 && defined BURN_BRIDGES \
-    || __FreeBSD_version >= 800098
+#if __FreeBSD_version >= 800069 && defined BURN_BRIDGES || __FreeBSD_version >= 800098
 #define IGMP_MEMBERSHIP_QUERY IGMP_HOST_MEMBERSHIP_QUERY
 #define IGMP_V1_MEMBERSHIP_REPORT IGMP_v1_HOST_MEMBERSHIP_REPORT
 #define IGMP_V2_MEMBERSHIP_REPORT IGMP_v2_HOST_MEMBERSHIP_REPORT
@@ -13,10 +12,9 @@
 #endif
 #define IGMP_V3_MEMBERSHIP_REPORT 0x22
 
-#define INADDR_ALLIGMPV3_GROUP ((in_addr_t) 0xe0000016)
+#define INADDR_ALLIGMPV3_GROUP ((in_addr_t)0xe0000016)
 
-static inline unsigned short ip_data_len(const struct ip *ip)
-{
+static inline unsigned short ip_data_len(const struct ip *ip) {
 #if __FreeBSD_version >= 1100030
     return ntohs(ip->ip_len) - (ip->ip_hl << 2);
 #elif __FreeBSD_version >= 900044
@@ -26,8 +24,7 @@ static inline unsigned short ip_data_len(const struct ip *ip)
 #endif
 }
 
-static inline void ip_set_len(struct ip *ip, unsigned short len)
-{
+static inline void ip_set_len(struct ip *ip, unsigned short len) {
 #if __FreeBSD_version >= 1100030
     ip->ip_len = htons(len);
 #else

--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -1,20 +1,18 @@
 #define _LINUX_IN_H
-#include <linux/types.h>
 #include <linux/mroute.h>
-#include <netinet/ip.h>
+#include <linux/types.h>
 #include <netinet/igmp.h>
+#include <netinet/ip.h>
 #include <sys/types.h>
 
 #define IGMP_V3_MEMBERSHIP_REPORT 0x22
 
-#define INADDR_ALLIGMPV3_GROUP ((in_addr_t) 0xe0000016)
+#define INADDR_ALLIGMPV3_GROUP ((in_addr_t)0xe0000016)
 
-static inline unsigned short ip_data_len(const struct ip *ip)
-{
+static inline unsigned short ip_data_len(const struct ip *ip) {
     return ntohs(ip->ip_len) - (ip->ip_hl << 2);
 }
 
-static inline void ip_set_len(struct ip *ip, unsigned short len)
-{
+static inline void ip_set_len(struct ip *ip, unsigned short len) {
     ip->ip_len = htons(len);
 }

--- a/src/os-netbsd.h
+++ b/src/os-netbsd.h
@@ -1,7 +1,7 @@
-#include <netinet/in_systm.h>
-#include <netinet/ip_mroute.h>
-#include <netinet/ip.h>
 #include <netinet/igmp.h>
+#include <netinet/in_systm.h>
+#include <netinet/ip.h>
+#include <netinet/ip_mroute.h>
 
 #define IGMP_MEMBERSHIP_QUERY IGMP_HOST_MEMBERSHIP_QUERY
 #define IGMP_V1_MEMBERSHIP_REPORT IGMP_v1_HOST_MEMBERSHIP_REPORT
@@ -9,14 +9,12 @@
 #define IGMP_V3_MEMBERSHIP_REPORT 0x22
 #define IGMP_V2_LEAVE_GROUP IGMP_HOST_LEAVE_MESSAGE
 
-#define INADDR_ALLIGMPV3_GROUP ((in_addr_t) 0xe0000016)
+#define INADDR_ALLIGMPV3_GROUP ((in_addr_t)0xe0000016)
 
-static inline unsigned short ip_data_len(const struct ip *ip)
-{
+static inline unsigned short ip_data_len(const struct ip *ip) {
     return ip->ip_len;
 }
 
-static inline void ip_set_len(struct ip *ip, unsigned short len)
-{
+static inline void ip_set_len(struct ip *ip, unsigned short len) {
     ip->ip_len = len;
 }

--- a/src/os-openbsd.h
+++ b/src/os-openbsd.h
@@ -1,7 +1,7 @@
-#include <netinet/in_systm.h>
-#include <netinet/ip_mroute.h>
-#include <netinet/ip.h>
 #include <netinet/igmp.h>
+#include <netinet/in_systm.h>
+#include <netinet/ip.h>
+#include <netinet/ip_mroute.h>
 
 #define IGMP_MEMBERSHIP_QUERY IGMP_HOST_MEMBERSHIP_QUERY
 #define IGMP_V1_MEMBERSHIP_REPORT IGMP_v1_HOST_MEMBERSHIP_REPORT
@@ -10,14 +10,12 @@
 #define IGMP_V2_LEAVE_GROUP IGMP_HOST_LEAVE_MESSAGE
 
 #define INADDR_ALLRTRS_GROUP INADDR_ALLROUTERS_GROUP
-#define INADDR_ALLIGMPV3_GROUP ((in_addr_t) 0xe0000016)
+#define INADDR_ALLIGMPV3_GROUP ((in_addr_t)0xe0000016)
 
-static inline unsigned short ip_data_len(const struct ip *ip)
-{
+static inline unsigned short ip_data_len(const struct ip *ip) {
     return ntohs(ip->ip_len) - (ip->ip_hl << 2);
 }
 
-static inline void ip_set_len(struct ip *ip, unsigned short len)
-{
+static inline void ip_set_len(struct ip *ip, unsigned short len) {
     ip->ip_len = htons(len);
 }

--- a/src/os-qnxnto.h
+++ b/src/os-qnxnto.h
@@ -1,21 +1,19 @@
-#include <netinet/in_systm.h>
-#include <netinet/ip_mroute.h>
-#include <netinet/ip.h>
 #include <netinet/igmp.h>
+#include <netinet/in_systm.h>
+#include <netinet/ip.h>
+#include <netinet/ip_mroute.h>
 
 #define IGMP_MEMBERSHIP_QUERY IGMP_HOST_MEMBERSHIP_QUERY
 #define IGMP_V1_MEMBERSHIP_REPORT IGMP_v1_HOST_MEMBERSHIP_REPORT
 #define IGMP_V2_MEMBERSHIP_REPORT IGMP_v2_HOST_MEMBERSHIP_REPORT
 #define IGMP_V2_LEAVE_GROUP IGMP_HOST_LEAVE_MESSAGE
 
-#define IPOPT_RA                148             /* router alert */
+#define IPOPT_RA 148 /* router alert */
 
-static inline u_short ip_data_len(const struct ip *ip)
-{
+static inline u_short ip_data_len(const struct ip *ip) {
     return ip->ip_len;
 }
 
-static inline void ip_set_len(struct ip *ip, u_short len)
-{
+static inline void ip_set_len(struct ip *ip, u_short len) {
     ip->ip_len = len;
 }

--- a/src/request.c
+++ b/src/request.c
@@ -44,98 +44,92 @@
 void sendGroupSpecificMemberQuery(void *argument);
 
 typedef struct {
-    uint32_t      group;
+    uint32_t group;
     // uint32_t      vifAddr;
-    short       started;
+    short started;
 } GroupVifDesc;
 
-
-/**
-*   Handles incoming membership reports, and
-*   appends them to the routing table.
-*/
+/*******************************************************************************
+ * Handles incoming membership reports, and appends them to the routing table.
+ ******************************************************************************/
 void acceptGroupReport(uint32_t src, uint32_t group) {
-    struct IfDesc  *sourceVif;
+    struct IfDesc *sourceVif;
 
     // Sanitycheck the group adress...
-    if(!IN_MULTICAST( ntohl(group) )) {
-        my_log(LOG_WARNING, 0, "The group address %s is not a valid Multicast group.",
-            inetFmt(group, s1));
+    if (!IN_MULTICAST(ntohl(group))) {
+        my_log(LOG_WARNING, 0, "The group address %s is not a valid Multicast group.", inetFmt(group, s1));
         return;
     }
 
     // Find the interface on which the report was received.
-    sourceVif = getIfByAddress( src );
-    if(sourceVif == NULL) {
-        my_log(LOG_WARNING, 0, "No interfaces found for source %s",
-            inetFmt(src,s1));
+    sourceVif = getIfByAddress(src);
+    if (sourceVif == NULL) {
+        my_log(LOG_WARNING, 0, "No interfaces found for source %s", inetFmt(src, s1));
         return;
     }
 
-    if(sourceVif->InAdr.s_addr == src) {
+    if (sourceVif->InAdr.s_addr == src) {
         my_log(LOG_NOTICE, 0, "The IGMP message was from myself. Ignoring.");
         return;
     }
 
     // We have a IF so check that it's an downstream IF.
-    if(sourceVif->state == IF_STATE_DOWNSTREAM) {
+    if (sourceVif->state == IF_STATE_DOWNSTREAM) {
 
-        my_log(LOG_DEBUG, 0, "Should insert group %s (from: %s) to route table. Vif Ix : %d",
-            inetFmt(group,s1), inetFmt(src,s2), sourceVif->index);
+        my_log(LOG_DEBUG, 0, "Should insert group %s (from: %s) to route table. Vif Ix : %d", inetFmt(group, s1),
+               inetFmt(src, s2), sourceVif->index);
 
         // If we don't have a whitelist we insertRoute and done
-        if(sourceVif->allowedgroups == NULL)
-        {
+        if (sourceVif->allowedgroups == NULL) {
             insertRoute(group, sourceVif->index);
             return;
         }
         // Check if this Request is legit on this interface
         struct SubnetList *sn;
-        for(sn = sourceVif->allowedgroups; sn != NULL; sn = sn->next)
-            if((group & sn->subnet_mask) == sn->subnet_addr)
-            {
+        for (sn = sourceVif->allowedgroups; sn != NULL; sn = sn->next)
+            if ((group & sn->subnet_mask) == sn->subnet_addr) {
                 // The membership report was OK... Insert it into the route table..
                 insertRoute(group, sourceVif->index);
                 return;
-        }
-    my_log(LOG_INFO, 0, "The group address %s may not be requested from this interface. Ignoring.", inetFmt(group, s1));
+            }
+        my_log(LOG_INFO, 0,
+               "The group address %s may not be requested from this "
+               "interface. Ignoring.",
+               inetFmt(group, s1));
     } else {
         // Log the state of the interface the report was received on.
         my_log(LOG_INFO, 0, "Mebership report was received on %s. Ignoring.",
-            sourceVif->state==IF_STATE_UPSTREAM?"the upstream interface":"a disabled interface");
+               sourceVif->state == IF_STATE_UPSTREAM ? "the upstream interface" : "a disabled interface");
     }
 }
 
-/**
-*   Recieves and handles a group leave message.
-*/
+/*******************************************************************************
+ *  Recieves and handles a group leave message.
+ ******************************************************************************/
 void acceptLeaveMessage(uint32_t src, uint32_t group) {
-    struct IfDesc   *sourceVif;
+    struct IfDesc *sourceVif;
 
-    my_log(LOG_DEBUG, 0,
-        "Got leave message from %s to %s. Starting last member detection.",
-        inetFmt(src, s1), inetFmt(group, s2));
+    my_log(LOG_DEBUG, 0, "Got leave message from %s to %s. Starting last member detection.", inetFmt(src, s1),
+           inetFmt(group, s2));
 
     // Sanitycheck the group adress...
-    if(!IN_MULTICAST( ntohl(group) )) {
-        my_log(LOG_WARNING, 0, "The group address %s is not a valid Multicast group.",
-            inetFmt(group, s1));
+    if (!IN_MULTICAST(ntohl(group))) {
+        my_log(LOG_WARNING, 0, "The group address %s is not a valid Multicast group.", inetFmt(group, s1));
         return;
     }
 
     // Find the interface on which the report was received.
-    sourceVif = getIfByAddress( src );
-    if(sourceVif == NULL) {
-        my_log(LOG_WARNING, 0, "No interfaces found for source %s",
-            inetFmt(src,s1));
+    sourceVif = getIfByAddress(src);
+    if (sourceVif == NULL) {
+        my_log(LOG_WARNING, 0, "No interfaces found for source %s", inetFmt(src, s1));
         return;
     }
 
     // We have a IF so check that it's an downstream IF.
-    if(sourceVif->state == IF_STATE_DOWNSTREAM) {
+    if (sourceVif->state == IF_STATE_DOWNSTREAM) {
 
-        GroupVifDesc   *gvDesc;
-        gvDesc = (GroupVifDesc*) malloc(sizeof(GroupVifDesc));
+        GroupVifDesc *gvDesc;
+        gvDesc = (GroupVifDesc *)malloc(sizeof(GroupVifDesc));
 
         // Tell the route table that we are checking for remaining members...
         setRouteLastMemberMode(group);
@@ -146,29 +140,28 @@ void acceptLeaveMessage(uint32_t src, uint32_t group) {
         gvDesc->started = 0;
 
         sendGroupSpecificMemberQuery(gvDesc);
-
     } else {
         // just ignore the leave request...
         my_log(LOG_DEBUG, 0, "The found if for %s was not downstream. Ignoring leave request.", inetFmt(src, s1));
     }
 }
 
-/**
-*   Sends a group specific member report query until the
-*   group times out...
-*/
+
+/*******************************************************************************
+ *  Sends a group specific member report query until the group times out...
+ ******************************************************************************/
 void sendGroupSpecificMemberQuery(void *argument) {
-    struct  Config  *conf = getCommonConfig();
-    struct  IfDesc  *Dp;
-    struct  RouteTable  *croute;
-    int     Ix;
+    struct Config *conf = getCommonConfig();
+    struct IfDesc *Dp;
+    struct RouteTable *croute;
+    int Ix;
 
     // Cast argument to correct type...
-    GroupVifDesc   *gvDesc = (GroupVifDesc*) argument;
+    GroupVifDesc *gvDesc = (GroupVifDesc *)argument;
 
-    if(gvDesc->started) {
+    if (gvDesc->started) {
         // If aging returns false, we don't do any further action...
-        if(!lastMemberGroupAge(gvDesc->group)) {
+        if (!lastMemberGroupAge(gvDesc->group)) {
             // FIXME: Should we free gvDesc here?
             return;
         }
@@ -177,26 +170,27 @@ void sendGroupSpecificMemberQuery(void *argument) {
     }
 
     /**
-     * FIXME: This loops through all interfaces the group is active on an sends queries.
-     *        It might be better to send only a query on the interface the leave was accepted on and remove only that interface from the route.
+     * FIXME:
+     * This loops through all interfaces the group is active on and sends
+     * queries.
+     *
+     * It might be better to send only a query on the interface the leave
+     * was accepted on and remove only that interface from the route.
      */
 
     // Loop through all downstream interfaces
-    for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) {
-        if ( Dp->InAdr.s_addr && ! (Dp->Flags & IFF_LOOPBACK) ) {
-            if(Dp->state == IF_STATE_DOWNSTREAM) {
+    for (Ix = 0; (Dp = getIfByIx(Ix)); Ix++) {
+        if (Dp->InAdr.s_addr && !(Dp->Flags & IFF_LOOPBACK)) {
+            if (Dp->state == IF_STATE_DOWNSTREAM) {
                 // Is that interface used in the group?
-                if (interfaceInRoute(gvDesc->group ,Dp->index)) {
+                if (interfaceInRoute(gvDesc->group, Dp->index)) {
 
                     // Send a group specific membership query...
-                    sendIgmp(Dp->InAdr.s_addr, gvDesc->group,
-                            IGMP_MEMBERSHIP_QUERY,
-                            conf->lastMemberQueryInterval * IGMP_TIMER_SCALE,
-                            gvDesc->group, 0);
+                    sendIgmp(Dp->InAdr.s_addr, gvDesc->group, IGMP_MEMBERSHIP_QUERY,
+                             conf->lastMemberQueryInterval * IGMP_TIMER_SCALE, gvDesc->group, 0);
 
                     my_log(LOG_DEBUG, 0, "Sent membership query from %s to %s. Delay: %d",
-                            inetFmt(Dp->InAdr.s_addr,s1), inetFmt(gvDesc->group,s2),
-                            conf->lastMemberQueryInterval);
+                           inetFmt(Dp->InAdr.s_addr, s1), inetFmt(gvDesc->group, s2), conf->lastMemberQueryInterval);
                 }
             }
         }
@@ -206,29 +200,24 @@ void sendGroupSpecificMemberQuery(void *argument) {
     timer_setTimer(conf->lastMemberQueryInterval, sendGroupSpecificMemberQuery, gvDesc);
 }
 
-
-/**
-*   Sends a general membership query on downstream VIFs
-*/
+/*******************************************************************************
+ *  Sends a general membership query on downstream VIFs
+ ******************************************************************************/
 void sendGeneralMembershipQuery(void) {
-    struct  Config  *conf = getCommonConfig();
-    struct  IfDesc  *Dp;
-    int             Ix;
+    struct Config *conf = getCommonConfig();
+    struct IfDesc *Dp;
+    int Ix;
 
     // Loop through all downstream vifs...
-    for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) {
-        if ( Dp->InAdr.s_addr && ! (Dp->Flags & IFF_LOOPBACK) ) {
-            if(Dp->state == IF_STATE_DOWNSTREAM) {
+    for (Ix = 0; (Dp = getIfByIx(Ix)); Ix++) {
+        if (Dp->InAdr.s_addr && !(Dp->Flags & IFF_LOOPBACK)) {
+            if (Dp->state == IF_STATE_DOWNSTREAM) {
                 // Send the membership query...
-                sendIgmp(Dp->InAdr.s_addr, allhosts_group,
-                         IGMP_MEMBERSHIP_QUERY,
+                sendIgmp(Dp->InAdr.s_addr, allhosts_group, IGMP_MEMBERSHIP_QUERY,
                          conf->queryResponseInterval * IGMP_TIMER_SCALE, 0, 0);
 
-                my_log(LOG_DEBUG, 0,
-                    "Sent membership query from %s to %s. Delay: %d",
-                    inetFmt(Dp->InAdr.s_addr,s1),
-                    inetFmt(allhosts_group,s2),
-                    conf->queryResponseInterval);
+                my_log(LOG_DEBUG, 0, "Sent membership query from %s to %s. Delay: %d", inetFmt(Dp->InAdr.s_addr, s1),
+                       inetFmt(allhosts_group, s2), conf->queryResponseInterval);
             }
         }
     }
@@ -237,13 +226,12 @@ void sendGeneralMembershipQuery(void) {
     timer_setTimer(conf->queryResponseInterval, (timer_f)ageActiveRoutes, NULL);
 
     // Install timer for next general query...
-    if(conf->startupQueryCount>0) {
+    if (conf->startupQueryCount > 0) {
         // Use quick timer...
         timer_setTimer(conf->startupQueryInterval, (timer_f)sendGeneralMembershipQuery, NULL);
         // Decrease startup counter...
         conf->startupQueryCount--;
-    }
-    else {
+    } else {
         // Use slow timer...
         timer_setTimer(conf->queryInterval, (timer_f)sendGeneralMembershipQuery, NULL);
     }

--- a/src/rttable.c
+++ b/src/rttable.c
@@ -46,25 +46,26 @@
 *   Routing table structure definition. Double linked list...
 */
 struct RouteTable {
-    struct RouteTable   *nextroute;     // Pointer to the next group in line.
-    struct RouteTable   *prevroute;     // Pointer to the previous group in line.
-    uint32_t            group;          // The group to route
-    uint32_t            originAddrs[MAX_ORIGINS]; // The origin adresses (only set on activated routes)
-    uint32_t            vifBits;        // Bits representing recieving VIFs.
+    struct RouteTable *nextroute;      // Pointer to the next group in line.
+    struct RouteTable *prevroute;      // Pointer to the previous group in line.
+    uint32_t group;                    // The group to route
+    uint32_t originAddrs[MAX_ORIGINS]; // The origin adresses (only set on
+                                       // activated routes)
+    uint32_t vifBits;                  // Bits representing recieving VIFs.
 
     // Keeps the upstream membership state...
-    short               upstrState;     // Upstream membership state.
-    int                 upstrVif;       // Upstream Vif Index.
+    short upstrState; // Upstream membership state.
+    int upstrVif;     // Upstream Vif Index.
 
     // These parameters contain aging details.
-    uint32_t            ageVifBits;     // Bits representing aging VIFs.
-    int                 ageValue;       // Downcounter for death.
-    int                 ageActivity;    // Records any acitivity that notes there are still listeners.
+    uint32_t ageVifBits; // Bits representing aging VIFs.
+    int ageValue;        // Downcounter for death.
+    int ageActivity;     // Records any acitivity that notes there are still
+                         // listeners.
 };
 
-
 // Keeper for the routing table...
-static struct RouteTable   *routing_table;
+static struct RouteTable *routing_table;
 
 // Prototypes
 void logRouteTable(const char *header);
@@ -74,13 +75,13 @@ int internUpdateKernelRoute(struct RouteTable *route, int activate);
 // Socket for sending join or leave requests.
 int mcGroupSock = 0;
 
-
 /**
 *   Function for retrieving the Multicast Group socket.
 */
 int getMcGroupSock(void) {
-    if( ! mcGroupSock ) {
-        mcGroupSock = openUdpSocket( INADDR_ANY, 0 );;
+    if (!mcGroupSock) {
+        mcGroupSock = openUdpSocket(INADDR_ANY, 0);
+        ;
     }
     return mcGroupSock;
 }
@@ -96,18 +97,18 @@ void initRouteTable(void) {
     routing_table = NULL;
 
     // Join the all routers group on downstream vifs...
-    for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) {
+    for (Ix = 0; (Dp = getIfByIx(Ix)); Ix++) {
         // If this is a downstream vif, we should join the All routers group...
-        if( Dp->InAdr.s_addr && ! (Dp->Flags & IFF_LOOPBACK) && Dp->state == IF_STATE_DOWNSTREAM) {
-            my_log(LOG_DEBUG, 0, "Joining all-routers group %s on vif %s",
-                         inetFmt(allrouters_group,s1),inetFmt(Dp->InAdr.s_addr,s2));
+        if (Dp->InAdr.s_addr && !(Dp->Flags & IFF_LOOPBACK) && Dp->state == IF_STATE_DOWNSTREAM) {
+            my_log(LOG_DEBUG, 0, "Joining all-routers group %s on vif %s", inetFmt(allrouters_group, s1),
+                   inetFmt(Dp->InAdr.s_addr, s2));
 
-            //k_join(allrouters_group, Dp->InAdr.s_addr);
-            joinMcGroup( getMcGroupSock(), Dp, allrouters_group );
+            // k_join(allrouters_group, Dp->InAdr.s_addr);
+            joinMcGroup(getMcGroupSock(), Dp, allrouters_group);
 
-            my_log(LOG_DEBUG, 0, "Joining all igmpv3 multicast routers group %s on vif %s",
-                         inetFmt(alligmp3_group,s1),inetFmt(Dp->InAdr.s_addr,s2));
-            joinMcGroup( getMcGroupSock(), Dp, alligmp3_group );
+            my_log(LOG_DEBUG, 0, "Joining all igmpv3 multicast routers group %s on vif %s", inetFmt(alligmp3_group, s1),
+                   inetFmt(Dp->InAdr.s_addr, s2));
+            joinMcGroup(getMcGroupSock(), Dp, alligmp3_group);
         }
     }
 }
@@ -116,69 +117,64 @@ void initRouteTable(void) {
 *   Internal function to send join or leave requests for
 *   a specified route upstream...
 */
-static void sendJoinLeaveUpstream(struct RouteTable* route, int join) {
-    struct IfDesc*      upstrIf;
+static void sendJoinLeaveUpstream(struct RouteTable *route, int join) {
+    struct IfDesc *upstrIf;
     int i;
 
-    for(i=0; i<MAX_UPS_VIFS; i++)
-    {
-        if (-1 != upStreamIfIdx[i])
-        {
+    for (i = 0; i < MAX_UPS_VIFS; i++) {
+        if (-1 != upStreamIfIdx[i]) {
             // Get the upstream IF...
-            upstrIf = getIfByIx( upStreamIfIdx[i] );
-            if(upstrIf == NULL) {
-                my_log(LOG_ERR, 0 ,"FATAL: Unable to get Upstream IF.");
+            upstrIf = getIfByIx(upStreamIfIdx[i]);
+            if (upstrIf == NULL) {
+                my_log(LOG_ERR, 0, "FATAL: Unable to get Upstream IF.");
             }
 
             // Check if there is a white list for the upstram VIF
             if (upstrIf->allowedgroups != NULL) {
-              uint32_t           group = route->group;
-                struct SubnetList* sn;
+                uint32_t group = route->group;
+                struct SubnetList *sn;
 
                 // Check if this Request is legit to be forwarded to upstream
-                for(sn = upstrIf->allowedgroups; sn != NULL; sn = sn->next)
-                    if((group & sn->subnet_mask) == sn->subnet_addr)
+                for (sn = upstrIf->allowedgroups; sn != NULL; sn = sn->next)
+                    if ((group & sn->subnet_mask) == sn->subnet_addr)
                         // Forward is OK...
                         break;
 
                 if (sn == NULL) {
-                    my_log(LOG_INFO, 0, "The group address %s may not be forwarded upstream. Ignoring.", inetFmt(group, s1));
+                    my_log(LOG_INFO, 0, "The group address %s may not be forwarded upstream. Ignoring.",
+                           inetFmt(group, s1));
                     return;
                 }
             }
 
             // Send join or leave request...
-            if(join) {
+            if (join) {
                 // Only join a group if there are listeners downstream...
-                if(route->vifBits > 0) {
-                    my_log(LOG_DEBUG, 0, "Joining group %s upstream on IF address %s",
-                                 inetFmt(route->group, s1),
-                                 inetFmt(upstrIf->InAdr.s_addr, s2));
+                if (route->vifBits > 0) {
+                    my_log(LOG_DEBUG, 0, "Joining group %s upstream on IF address %s", inetFmt(route->group, s1),
+                           inetFmt(upstrIf->InAdr.s_addr, s2));
 
-                    //k_join(route->group, upstrIf->InAdr.s_addr);
-                    joinMcGroup( getMcGroupSock(), upstrIf, route->group );
+                    // k_join(route->group, upstrIf->InAdr.s_addr);
+                    joinMcGroup(getMcGroupSock(), upstrIf, route->group);
 
                     route->upstrState = ROUTESTATE_JOINED;
                 } else {
                     my_log(LOG_DEBUG, 0, "No downstream listeners for group %s. No join sent.",
-                        inetFmt(route->group, s1));
+                           inetFmt(route->group, s1));
                 }
             } else {
                 // Only leave if group is not left already...
-                if(route->upstrState != ROUTESTATE_NOTJOINED) {
-                    my_log(LOG_DEBUG, 0, "Leaving group %s upstream on IF address %s",
-                                 inetFmt(route->group, s1),
-                                 inetFmt(upstrIf->InAdr.s_addr, s2));
+                if (route->upstrState != ROUTESTATE_NOTJOINED) {
+                    my_log(LOG_DEBUG, 0, "Leaving group %s upstream on IF address %s", inetFmt(route->group, s1),
+                           inetFmt(upstrIf->InAdr.s_addr, s2));
 
-                    //k_leave(route->group, upstrIf->InAdr.s_addr);
-                    leaveMcGroup( getMcGroupSock(), upstrIf, route->group );
+                    // k_leave(route->group, upstrIf->InAdr.s_addr);
+                    leaveMcGroup(getMcGroupSock(), upstrIf, route->group);
 
                     route->upstrState = ROUTESTATE_NOTJOINED;
                 }
             }
-        }
-        else
-        {
+        } else {
             i = MAX_UPS_VIFS;
         }
     }
@@ -188,19 +184,18 @@ static void sendJoinLeaveUpstream(struct RouteTable* route, int join) {
 *   Clear all routes from routing table, and alerts Leaves upstream.
 */
 void clearAllRoutes(void) {
-    struct RouteTable   *croute, *remainroute;
+    struct RouteTable *croute, *remainroute;
 
     // Loop through all routes...
-    for(croute = routing_table; croute; croute = remainroute) {
+    for (croute = routing_table; croute; croute = remainroute) {
 
         remainroute = croute->nextroute;
 
         // Log the cleanup in debugmode...
-        my_log(LOG_DEBUG, 0, "Removing route entry for %s",
-                     inetFmt(croute->group, s1));
+        my_log(LOG_DEBUG, 0, "Removing route entry for %s", inetFmt(croute->group, s1));
 
         // Uninstall current route
-        if(!internUpdateKernelRoute(croute, 0)) {
+        if (!internUpdateKernelRoute(croute, 0)) {
             my_log(LOG_WARNING, 0, "The removal from Kernel failed.");
         }
 
@@ -221,10 +216,10 @@ void clearAllRoutes(void) {
 *   Route Descriptor.
 */
 static struct RouteTable *findRoute(uint32_t group) {
-    struct RouteTable*  croute;
+    struct RouteTable *croute;
 
-    for(croute = routing_table; croute; croute = croute->nextroute) {
-        if(croute->group == group) {
+    for (croute = routing_table; croute; croute = croute->nextroute) {
+        if (croute->group == group) {
             return croute;
         }
     }
@@ -240,57 +235,57 @@ static struct RouteTable *findRoute(uint32_t group) {
 int insertRoute(uint32_t group, int ifx) {
 
     struct Config *conf = getCommonConfig();
-    struct RouteTable*  croute;
+    struct RouteTable *croute;
 
     // Sanitycheck the group adress...
-    if( ! IN_MULTICAST( ntohl(group) )) {
-        my_log(LOG_WARNING, 0, "The group address %s is not a valid Multicast group. Table insert failed.",
-            inetFmt(group, s1));
+    if (!IN_MULTICAST(ntohl(group))) {
+        my_log(LOG_WARNING, 0,
+               "The group address %s is not a valid Multicast "
+               "group. Table insert failed.",
+               inetFmt(group, s1));
         return 0;
     }
 
     // Santiycheck the VIF index...
-    //if(ifx < 0 || ifx >= MAX_MC_VIFS) {
-    if(ifx >= MAX_MC_VIFS) {
-        my_log(LOG_WARNING, 0, "The VIF Ix %d is out of range (0-%d). Table insert failed.",ifx,MAX_MC_VIFS);
+    // if(ifx < 0 || ifx >= MAX_MC_VIFS) {
+    if (ifx >= MAX_MC_VIFS) {
+        my_log(LOG_WARNING, 0, "The VIF Ix %d is out of range (0-%d). Table insert failed.", ifx, MAX_MC_VIFS);
         return 0;
     }
 
     // Try to find an existing route for this group...
     croute = findRoute(group);
-    if(croute==NULL) {
-        struct RouteTable*  newroute;
+    if (croute == NULL) {
+        struct RouteTable *newroute;
 
-        my_log(LOG_DEBUG, 0, "No existing route for %s. Create new.",
-                     inetFmt(group, s1));
-
+        my_log(LOG_DEBUG, 0, "No existing route for %s. Create new.", inetFmt(group, s1));
 
         // Create and initialize the new route table entry..
-        newroute = (struct RouteTable*)malloc(sizeof(struct RouteTable));
+        newroute = (struct RouteTable *)malloc(sizeof(struct RouteTable));
         // Insert the route desc and clear all pointers...
-        newroute->group      = group;
+        newroute->group = group;
         memset(newroute->originAddrs, 0, MAX_ORIGINS * sizeof(newroute->originAddrs[0]));
-        newroute->nextroute  = NULL;
-        newroute->prevroute  = NULL;
-        newroute->upstrVif   = -1;
+        newroute->nextroute = NULL;
+        newroute->prevroute = NULL;
+        newroute->upstrVif = -1;
 
         // The group is not joined initially.
         newroute->upstrState = ROUTESTATE_NOTJOINED;
 
         // The route is not active yet, so the age is unimportant.
-        newroute->ageValue    = conf->robustnessValue;
+        newroute->ageValue = conf->robustnessValue;
         newroute->ageActivity = 0;
 
-        BIT_ZERO(newroute->ageVifBits);     // Initially we assume no listeners.
+        BIT_ZERO(newroute->ageVifBits); // Initially we assume no listeners.
 
         // Set the listener flag...
-        BIT_ZERO(newroute->vifBits);    // Initially no listeners...
-        if(ifx >= 0) {
+        BIT_ZERO(newroute->vifBits); // Initially no listeners...
+        if (ifx >= 0) {
             BIT_SET(newroute->vifBits, ifx);
         }
 
         // Check if there is a table already....
-        if(routing_table == NULL) {
+        if (routing_table == NULL) {
             // No location set, so insert in on the table top.
             routing_table = newroute;
             my_log(LOG_DEBUG, 0, "No routes in table. Insert at beginning.");
@@ -299,8 +294,8 @@ int insertRoute(uint32_t group, int ifx) {
             my_log(LOG_DEBUG, 0, "Found existing routes. Find insert location.");
 
             // Check if the route could be inserted at the beginning...
-            if(routing_table->group > group) {
-                my_log(LOG_DEBUG, 0, "Inserting at beginning, before route %s",inetFmt(routing_table->group,s1));
+            if (routing_table->group > group) {
+                my_log(LOG_DEBUG, 0, "Inserting at beginning, before route %s", inetFmt(routing_table->group, s1));
 
                 // Insert at beginning...
                 newroute->nextroute = routing_table;
@@ -308,26 +303,25 @@ int insertRoute(uint32_t group, int ifx) {
                 routing_table = newroute;
 
                 // If the route has a next node, the previous pointer must be updated.
-                if(newroute->nextroute != NULL) {
+                if (newroute->nextroute != NULL) {
                     newroute->nextroute->prevroute = newroute;
                 }
-
             } else {
 
                 // Find the location which is closest to the route.
-                for( croute = routing_table; croute->nextroute != NULL; croute = croute->nextroute ) {
+                for (croute = routing_table; croute->nextroute != NULL; croute = croute->nextroute) {
                     // Find insert position.
-                    if(croute->nextroute->group > group) {
+                    if (croute->nextroute->group > group) {
                         break;
                     }
                 }
 
-                my_log(LOG_DEBUG, 0, "Inserting after route %s",inetFmt(croute->group,s1));
+                my_log(LOG_DEBUG, 0, "Inserting after route %s", inetFmt(croute->group, s1));
 
                 // Insert after current...
                 newroute->nextroute = croute->nextroute;
                 newroute->prevroute = croute;
-                if(croute->nextroute != NULL) {
+                if (croute->nextroute != NULL) {
                     croute->nextroute->prevroute = newroute;
                 }
                 croute->nextroute = newroute;
@@ -338,10 +332,8 @@ int insertRoute(uint32_t group, int ifx) {
         croute = newroute;
 
         // Log the cleanup in debugmode...
-        my_log(LOG_INFO, 0, "Inserted route table entry for %s on VIF #%d",
-            inetFmt(croute->group, s1),ifx);
-
-    } else if(ifx >= 0) {
+        my_log(LOG_INFO, 0, "Inserted route table entry for %s on VIF #%d", inetFmt(croute->group, s1), ifx);
+    } else if (ifx >= 0) {
 
         // The route exists already, so just update it.
         BIT_SET(croute->vifBits, ifx);
@@ -350,20 +342,19 @@ int insertRoute(uint32_t group, int ifx) {
         BIT_SET(croute->ageVifBits, ifx);
 
         // Log the cleanup in debugmode...
-        my_log(LOG_INFO, 0, "Updated route entry for %s on VIF #%d",
-            inetFmt(croute->group, s1), ifx);
+        my_log(LOG_INFO, 0, "Updated route entry for %s on VIF #%d", inetFmt(croute->group, s1), ifx);
 
         // Update route in kernel...
-        if(!internUpdateKernelRoute(croute, 1)) {
+        if (!internUpdateKernelRoute(croute, 1)) {
             my_log(LOG_WARNING, 0, "The insertion into Kernel failed.");
             return 0;
         }
     }
 
     // Send join message upstream, if the route has no joined flag...
-    if(croute->upstrState != ROUTESTATE_JOINED) {
+    if (croute->upstrState != ROUTESTATE_JOINED) {
         // Send Join request upstream
-        struct IfDesc*      downstrIf;
+        struct IfDesc *downstrIf;
         downstrIf = getIfByIx(ifx);
         sendJoinLeaveUpstream(croute, 1);
     }
@@ -379,15 +370,14 @@ int insertRoute(uint32_t group, int ifx) {
 *   the route is activated, no originAddr is needed.
 */
 int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif) {
-    struct RouteTable*  croute;
+    struct RouteTable *croute;
     int result = 0;
 
     // Find the requested route.
     croute = findRoute(group);
-    if(croute == NULL) {
-        my_log(LOG_DEBUG, 0,
-            "No table entry for %s [From: %s]. Inserting route.",
-            inetFmt(group, s1),inetFmt(originAddr, s2));
+    if (croute == NULL) {
+        my_log(LOG_DEBUG, 0, "No table entry for %s [From: %s]. Inserting route.", inetFmt(group, s1),
+               inetFmt(originAddr, s2));
 
         // Insert route, but no interfaces have yet requested it downstream.
         insertRoute(group, -1);
@@ -396,9 +386,9 @@ int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif) {
         croute = findRoute(group);
     }
 
-    if(croute != NULL) {
+    if (croute != NULL) {
         // If the origin address is set, update the route data.
-        if(originAddr > 0) {
+        if (originAddr > 0) {
             // find this origin, or an unused slot
             int i;
             for (i = 0; i < MAX_ORIGINS; i++) {
@@ -412,9 +402,7 @@ int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif) {
                 i = MAX_ORIGINS - 1;
 
                 my_log(LOG_WARNING, 0, "Too many origins for route %s; replacing %s with %s",
-                    inetFmt(croute->group, s1),
-                    inetFmt(croute->originAddrs[i], s2),
-                    inetFmt(originAddr, s3));
+                       inetFmt(croute->group, s1), inetFmt(croute->originAddrs[i], s2), inetFmt(originAddr, s3));
             }
 
             // set origin
@@ -431,7 +419,7 @@ int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif) {
         croute->upstrVif = upstrVif;
 
         // Only update kernel table if there are listeners !
-        if(croute->vifBits > 0) {
+        if (croute->vifBits > 0) {
             result = internUpdateKernelRoute(croute, 1);
         }
     }
@@ -440,24 +428,23 @@ int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif) {
     return result;
 }
 
-
 /**
 *   This function loops through all routes, and updates the age
 *   of any active routes.
 */
 void ageActiveRoutes(void) {
-    struct RouteTable   *croute, *nroute;
+    struct RouteTable *croute, *nroute;
 
     my_log(LOG_DEBUG, 0, "Aging routes in table.");
 
     // Scan all routes...
-    for( croute = routing_table; croute != NULL; croute = nroute ) {
+    for (croute = routing_table; croute != NULL; croute = nroute) {
 
         // Keep the next route (since current route may be removed)...
         nroute = croute->nextroute;
 
         // Run the aging round algorithm.
-        if(croute->upstrState != ROUTESTATE_CHECK_LAST_MEMBER) {
+        if (croute->upstrState != ROUTESTATE_CHECK_LAST_MEMBER) {
             // Only age routes if Last member probe is not active...
             internAgeRoute(croute);
         }
@@ -473,9 +460,9 @@ int numberOfInterfaces(struct RouteTable *croute) {
     struct IfDesc *Dp;
     int result = 0;
     // Loop through all interfaces
-    for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) {
+    for (Ix = 0; (Dp = getIfByIx(Ix)); Ix++) {
         // If the interface is used by the route, increase counter
-        if(BIT_TST(croute->vifBits, Dp->index)) {
+        if (BIT_TST(croute->vifBits, Dp->index)) {
             result++;
         }
     }
@@ -488,14 +475,15 @@ int numberOfInterfaces(struct RouteTable *croute) {
 *   mark a route for the last member probe state.
 */
 void setRouteLastMemberMode(uint32_t group) {
-    struct Config       *conf = getCommonConfig();
-    struct RouteTable   *croute;
+    struct Config *conf = getCommonConfig();
+    struct RouteTable *croute;
 
     croute = findRoute(group);
-    if(croute!=NULL) {
+    if (croute != NULL) {
         // Check for fast leave mode...
-        if(croute->upstrState == ROUTESTATE_JOINED && conf->fastUpstreamLeave) {
-            // Send a leave message right away only when the route has been active on only one interface
+        if (croute->upstrState == ROUTESTATE_JOINED && conf->fastUpstreamLeave) {
+            // Send a leave message right away only when the route has been active on
+            // only one interface
             if (numberOfInterfaces(croute) <= 1) {
                 my_log(LOG_DEBUG, 0, "Leaving group %d now", group);
                 sendJoinLeaveUpstream(croute, 0);
@@ -510,17 +498,16 @@ void setRouteLastMemberMode(uint32_t group) {
     }
 }
 
-
 /**
 *   Ages groups in the last member check state. If the
 *   route is not found, or not in this state, 0 is returned.
 */
 int lastMemberGroupAge(uint32_t group) {
-    struct RouteTable   *croute;
+    struct RouteTable *croute;
 
     croute = findRoute(group);
-    if(croute!=NULL) {
-        if(croute->upstrState == ROUTESTATE_CHECK_LAST_MEMBER) {
+    if (croute != NULL) {
+        if (croute->upstrState == ROUTESTATE_CHECK_LAST_MEMBER) {
             return !internAgeRoute(croute);
         } else {
             return 0;
@@ -533,45 +520,42 @@ int lastMemberGroupAge(uint32_t group) {
 *   Remove a specified route. Returns 1 on success,
 *   and 0 if route was not found.
 */
-static int removeRoute(struct RouteTable*  croute) {
-    struct Config       *conf = getCommonConfig();
+static int removeRoute(struct RouteTable *croute) {
+    struct Config *conf = getCommonConfig();
     int result = 1;
 
     // If croute is null, no routes was found.
-    if(croute==NULL) {
+    if (croute == NULL) {
         return 0;
     }
 
     // Log the cleanup in debugmode...
-    my_log(LOG_DEBUG, 0, "Removed route entry for %s from table.",
-                 inetFmt(croute->group, s1));
+    my_log(LOG_DEBUG, 0, "Removed route entry for %s from table.", inetFmt(croute->group, s1));
 
-    //BIT_ZERO(croute->vifBits);
+    // BIT_ZERO(croute->vifBits);
 
     // Uninstall current route from kernel
-    if(!internUpdateKernelRoute(croute, 0)) {
+    if (!internUpdateKernelRoute(croute, 0)) {
         my_log(LOG_WARNING, 0, "The removal from Kernel failed.");
         result = 0;
     }
 
     // Send Leave request upstream if group is joined
-    if(croute->upstrState == ROUTESTATE_JOINED || 
-       (croute->upstrState == ROUTESTATE_CHECK_LAST_MEMBER && !conf->fastUpstreamLeave)) 
-    {
+    if (croute->upstrState == ROUTESTATE_JOINED ||
+        (croute->upstrState == ROUTESTATE_CHECK_LAST_MEMBER && !conf->fastUpstreamLeave)) {
         sendJoinLeaveUpstream(croute, 0);
     }
 
     // Update pointers...
-    if(croute->prevroute == NULL) {
+    if (croute->prevroute == NULL) {
         // Topmost node...
-        if(croute->nextroute != NULL) {
+        if (croute->nextroute != NULL) {
             croute->nextroute->prevroute = NULL;
         }
         routing_table = croute->nextroute;
-
     } else {
         croute->prevroute->nextroute = croute->nextroute;
-        if(croute->nextroute != NULL) {
+        if (croute->nextroute != NULL) {
             croute->nextroute->prevroute = croute->prevroute;
         }
     }
@@ -584,11 +568,10 @@ static int removeRoute(struct RouteTable*  croute) {
     return result;
 }
 
-
 /**
 *   Ages a specific route
 */
-int internAgeRoute(struct RouteTable*  croute) {
+int internAgeRoute(struct RouteTable *croute) {
     struct Config *conf = getCommonConfig();
     int result = 0;
 
@@ -596,12 +579,12 @@ int internAgeRoute(struct RouteTable*  croute) {
     croute->ageValue--;
 
     // Check if there has been any activity...
-    if( croute->ageVifBits > 0 && croute->ageActivity == 0 ) {
+    if (croute->ageVifBits > 0 && croute->ageActivity == 0) {
         // There was some activity, check if all registered vifs responded.
-        if(croute->vifBits == croute->ageVifBits) {
+        if (croute->vifBits == croute->ageVifBits) {
             // Everything is in perfect order, so we just update the route age.
             croute->ageValue = conf->robustnessValue;
-            //croute->ageActivity = 0;
+            // croute->ageActivity = 0;
         } else {
             // One or more VIF has not gotten any response.
             croute->ageActivity++;
@@ -611,10 +594,10 @@ int internAgeRoute(struct RouteTable*  croute) {
         }
     }
     // Check if there have been activity in aging process...
-    else if( croute->ageActivity > 0 ) {
+    else if (croute->ageActivity > 0) {
 
         // If the bits are different in this round, we must
-        if(croute->vifBits != croute->ageVifBits) {
+        if (croute->vifBits != croute->ageVifBits) {
             // Or the bits together to insure we don't lose any listeners.
             croute->vifBits |= croute->ageVifBits;
 
@@ -624,12 +607,11 @@ int internAgeRoute(struct RouteTable*  croute) {
     }
 
     // If the aging counter has reached zero, its time for updating...
-    if(croute->ageValue == 0) {
+    if (croute->ageValue == 0) {
         // Check for activity in the aging process,
-        if(croute->ageActivity>0) {
+        if (croute->ageActivity > 0) {
 
-            my_log(LOG_DEBUG, 0, "Updating route after aging : %s",
-                         inetFmt(croute->group,s1));
+            my_log(LOG_DEBUG, 0, "Updating route after aging : %s", inetFmt(croute->group, s1));
 
             // Just update the routing settings in kernel...
             internUpdateKernelRoute(croute, 1);
@@ -639,8 +621,7 @@ int internAgeRoute(struct RouteTable*  croute) {
             croute->ageActivity = 0;
         } else {
 
-            my_log(LOG_DEBUG, 0, "Removing group %s. Died of old age.",
-                         inetFmt(croute->group,s1));
+            my_log(LOG_DEBUG, 0, "Removing group %s. Died of old age.", inetFmt(croute->group, s1));
 
             // No activity was registered within the timelimit, so remove the route.
             removeRoute(croute);
@@ -660,10 +641,10 @@ int internAgeRoute(struct RouteTable*  croute) {
 *   is (re-)activated. If activate is false, the route is removed.
 */
 int internUpdateKernelRoute(struct RouteTable *route, int activate) {
-    struct   MRouteDesc mrDesc;
-    struct   IfDesc     *Dp;
-    unsigned            Ix;
-    int                 i;
+    struct MRouteDesc mrDesc;
+    struct IfDesc *Dp;
+    unsigned Ix;
+    int i;
 
     for (int i = 0; i < MAX_ORIGINS; i++) {
         if (route->originAddrs[i] == 0 || route->upstrVif == -1) {
@@ -672,34 +653,33 @@ int internUpdateKernelRoute(struct RouteTable *route, int activate) {
 
         // Build route descriptor from table entry...
         // Set the source address and group address...
-        mrDesc.McAdr.s_addr     = route->group;
+        mrDesc.McAdr.s_addr = route->group;
         mrDesc.OriginAdr.s_addr = route->originAddrs[i];
 
         // clear output interfaces
-        memset( mrDesc.TtlVc, 0, sizeof( mrDesc.TtlVc ) );
+        memset(mrDesc.TtlVc, 0, sizeof(mrDesc.TtlVc));
 
         my_log(LOG_DEBUG, 0, "Vif bits : 0x%08x", route->vifBits);
 
         mrDesc.InVif = route->upstrVif;
 
         // Set the TTL's for the route descriptor...
-        for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) {
-            if(Dp->state == IF_STATE_UPSTREAM) {
+        for (Ix = 0; (Dp = getIfByIx(Ix)); Ix++) {
+            if (Dp->state == IF_STATE_UPSTREAM) {
                 continue;
-            }
-            else if(BIT_TST(route->vifBits, Dp->index)) {
+            } else if (BIT_TST(route->vifBits, Dp->index)) {
                 my_log(LOG_DEBUG, 0, "Setting TTL for Vif %d to %d", Dp->index, Dp->threshold);
-                mrDesc.TtlVc[ Dp->index ] = Dp->threshold;
+                mrDesc.TtlVc[Dp->index] = Dp->threshold;
             }
         }
 
         // Do the actual Kernel route update...
-        if(activate) {
+        if (activate) {
             // Add route in kernel...
-            addMRoute( &mrDesc );
+            addMRoute(&mrDesc);
         } else {
             // Delete the route from Kernel...
-            delMRoute( &mrDesc );
+            delMRoute(&mrDesc);
         }
     }
 
@@ -711,47 +691,45 @@ int internUpdateKernelRoute(struct RouteTable *route, int activate) {
 *   to the log.
 */
 void logRouteTable(const char *header) {
-        struct RouteTable   *croute = routing_table;
-        unsigned            rcount = 0;
+    struct RouteTable *croute = routing_table;
+    unsigned rcount = 0;
 
-        my_log(LOG_DEBUG, 0, "");
-        my_log(LOG_DEBUG, 0, "Current routing table (%s):", header);
-        my_log(LOG_DEBUG, 0, "-----------------------------------------------------");
-        if(croute==NULL) {
-            my_log(LOG_DEBUG, 0, "No routes in table...");
-        } else {
-            do {
-                char st = 'I';
-                char src[MAX_ORIGINS * 30 + 1];
-                src[0] = '\0';
+    my_log(LOG_DEBUG, 0, "");
+    my_log(LOG_DEBUG, 0, "Current routing table (%s):", header);
+    my_log(LOG_DEBUG, 0, "-----------------------------------------------------");
+    if (croute == NULL) {
+        my_log(LOG_DEBUG, 0, "No routes in table...");
+    } else {
+        do {
+            char st = 'I';
+            char src[MAX_ORIGINS * 30 + 1];
+            src[0] = '\0';
 
-                for (int i = 0; i < MAX_ORIGINS; i++) {
-                    if (croute->originAddrs[i] == 0) {
-                        continue;
-                    }
-                    st = 'A';
-                    sprintf(src + strlen(src), "Src%d: %s, ", i, inetFmt(croute->originAddrs[i], s1));
+            for (int i = 0; i < MAX_ORIGINS; i++) {
+                if (croute->originAddrs[i] == 0) {
+                    continue;
                 }
+                st = 'A';
+                sprintf(src + strlen(src), "Src%d: %s, ", i, inetFmt(croute->originAddrs[i], s1));
+            }
 
-                my_log(LOG_DEBUG, 0, "#%d: %sDst: %s, Age:%d, St: %c, OutVifs: 0x%08x",
-                    rcount, src, inetFmt(croute->group, s2),
-                    croute->ageValue, st,
-                    croute->vifBits);
+            my_log(LOG_DEBUG, 0, "#%d: %sDst: %s, Age:%d, St: %c, OutVifs: 0x%08x", rcount, src,
+                   inetFmt(croute->group, s2), croute->ageValue, st, croute->vifBits);
 
-                croute = croute->nextroute;
+            croute = croute->nextroute;
 
-                rcount++;
-            } while ( croute != NULL );
-        }
+            rcount++;
+        } while (croute != NULL);
+    }
 
-        my_log(LOG_DEBUG, 0, "-----------------------------------------------------");
+    my_log(LOG_DEBUG, 0, "-----------------------------------------------------");
 }
 
 /**
 *   Returns true when the given group belongs to the given interface
 */
 int interfaceInRoute(int32_t group, int Ix) {
-    struct RouteTable*  croute;
+    struct RouteTable *croute;
     croute = findRoute(group);
     if (croute != NULL) {
         my_log(LOG_DEBUG, 0, "Interface id %d is in group $d", Ix, group);

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -37,18 +37,16 @@
 int LogLevel = LOG_WARNING;
 bool Log2Stderr = false;
 
-void my_log( int Severity, int Errno, const char *FmtSt, ... )
-{
-    char LogMsg[ 128 ];
+void my_log(int Severity, int Errno, const char *FmtSt, ...) {
+    char LogMsg[128];
 
     va_list ArgPt;
     unsigned Ln;
-    va_start( ArgPt, FmtSt );
-    Ln = vsnprintf( LogMsg, sizeof( LogMsg ), FmtSt, ArgPt );
-    if( Errno > 0 )
-        snprintf( LogMsg + Ln, sizeof( LogMsg ) - Ln,
-                "; Errno(%d): %s", Errno, strerror(Errno) );
-    va_end( ArgPt );
+    va_start(ArgPt, FmtSt);
+    Ln = vsnprintf(LogMsg, sizeof(LogMsg), FmtSt, ArgPt);
+    if (Errno > 0)
+        snprintf(LogMsg + Ln, sizeof(LogMsg) - Ln, "; Errno(%d): %s", Errno, strerror(Errno));
+    va_end(ArgPt);
 
     if (Severity <= LogLevel) {
         if (Log2Stderr)
@@ -58,6 +56,6 @@ void my_log( int Severity, int Errno, const char *FmtSt, ... )
         }
     }
 
-    if( Severity <= LOG_ERR )
-        exit( -1 );
+    if (Severity <= LOG_ERR)
+        exit(-1);
 }

--- a/src/udpsock.c
+++ b/src/udpsock.c
@@ -46,21 +46,20 @@
 *   @param PeerPort  - The port to connect to
 *
 */
-int openUdpSocket( uint32_t PeerInAdr, uint16_t PeerPort ) {
+int openUdpSocket(uint32_t PeerInAdr, uint16_t PeerPort) {
     int Sock;
     struct sockaddr_in SockAdr;
 
-    if( (Sock = socket( AF_INET, SOCK_RAW, IPPROTO_IGMP )) < 0 )
-        my_log( LOG_ERR, errno, "UDP socket open" );
+    if ((Sock = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP)) < 0)
+        my_log(LOG_ERR, errno, "UDP socket open");
 
-    memset( &SockAdr, 0, sizeof( SockAdr ) );
-    SockAdr.sin_family      = AF_INET;
-    SockAdr.sin_port        = htons(PeerPort);
+    memset(&SockAdr, 0, sizeof(SockAdr));
+    SockAdr.sin_family = AF_INET;
+    SockAdr.sin_port = htons(PeerPort);
     SockAdr.sin_addr.s_addr = htonl(PeerInAdr);
 
-    if( bind( Sock, (struct sockaddr *)&SockAdr, sizeof( SockAdr ) ) )
-        my_log( LOG_ERR, errno, "UDP socket bind" );
+    if (bind(Sock, (struct sockaddr *)&SockAdr, sizeof(SockAdr)))
+        my_log(LOG_ERR, errno, "UDP socket bind");
 
     return Sock;
 }
-


### PR DESCRIPTION
The first commit introduces a new goal: `make reformat` based on clang-reformat (at least version 3.9 should be used).
This target is optional.

The second commit contains all changes after the execution of this command.

In the future committers can normalize their code by simply using the make goal.