### PR TITLE
Fix running as daemon

### DIFF
--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -79,7 +79,7 @@ int     upStreamIfIdx[MAX_UPS_VIFS];
 int main( int ArgCn, char *ArgVc[] ) {
 
     int c;
-    bool NotAsDaemon = true;
+    bool NotAsDaemon = false;
 
     // Parse the commandline options and setup basic settings..
     while ((c = getopt(ArgCn, ArgVc, "vdnh")) != -1) {


### PR DESCRIPTION
Commit 29eab814175d7754797c51ed6d4d1d7c91155cca introduced a new flag,
-n, which allows making igmpproxy not run as a daemon (fork and run in
the foreground). However, the boolean flag controlling this option was
always true, thus causing igmpproxy to never run as a daemon,
regardless whether the switch was specified or not.