### PR TITLE
Added changes to permit pppoe interfaces

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -396,7 +396,7 @@ struct SubnetList *parseSubnetAddress(char *addrstr) {
     }
 
     tmpSubnet = (struct SubnetList*) malloc(sizeof(struct SubnetList));
-    tmpSubnet->subnet_addr = addr;
+    tmpSubnet->subnet_addr = (addr & mask);
     tmpSubnet->subnet_mask = ntohl(mask);
     tmpSubnet->next = NULL;
 

--- a/src/config.c
+++ b/src/config.c
@@ -396,7 +396,7 @@ struct SubnetList *parseSubnetAddress(char *addrstr) {
     }
 
     tmpSubnet = (struct SubnetList*) malloc(sizeof(struct SubnetList));
-    tmpSubnet->subnet_addr = (addr & mask);
+    tmpSubnet->subnet_addr = addr;
     tmpSubnet->subnet_mask = ntohl(mask);
     tmpSubnet->next = NULL;
 

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -186,7 +186,7 @@ extern int upStreamIfIdx[MAX_UPS_VIFS];
  */
 void rebuildIfVc( void );
 void buildIfVc( void );
-struct IfDesc *getIfByName( const char *IfName );
+struct IfDesc *getIfByName( const char *IfName, int iponly );
 struct IfDesc *getIfByIx( unsigned Ix );
 struct IfDesc *getIfByAddress( uint32_t Ix );
 struct IfDesc *getIfByVifIndex( unsigned vifindex );


### PR DESCRIPTION
Workaround for:
**Igmpproxy is not starting if upstream interface is a pppoe interface [#28](https://github.com/pali/igmpproxy/issues/28)**