### PR TITLE
increase MAX_IF to 100

### DIFF
--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -113,7 +113,7 @@ void my_log( int Serverity, int Errno, const char *FmtSt, ... );
 
 /* ifvc.c
  */
-#define MAX_IF         40     // max. number of interfaces recognized
+#define MAX_IF         100     // max. number of interfaces recognized
 
 // Interface states
 #define IF_STATE_DISABLED      0   // Interface should be ignored.


### PR DESCRIPTION
Several users of OPNsense and pfSense report a persistent error
with their configuration: "There must be at least 1 Vif as upstream."

It seems that there is no real error in igmpproxy, but rather with
the way that network addresses are looked up prior to starting up.
This can break when many addresses are present in the system.

There is no exact science for the increase to 100 and previous custom
patches on both projects have had this raised to 80 back when version
0.1 was used.  There could be further work required to dynamically
parse addresses in a way that this raised limit does not cause further
issues in the future.

See also: https://github.com/opnsense/plugins/issues/590
See also: https://redmine.pfsense.org/issues/8935