### PR TITLE
Forward MembershipQuery from upstream to downstream

### DIFF
--- a/src/igmp.c
+++ b/src/igmp.c
@@ -251,7 +251,7 @@ void acceptIgmp(int recvlen) {
         return;
 
     case IGMP_MEMBERSHIP_QUERY:
-		acceptMembershipQuery(src);
+        acceptMembershipQuery(src);
         return;
 
     default:

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -251,6 +251,7 @@ void acceptIgmp(int recvlen) {
         return;
 
     case IGMP_MEMBERSHIP_QUERY:
+		acceptMembershipQuery(src);
         return;
 
     default:

--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -273,7 +273,7 @@ void igmpProxyRun(void) {
     lasttime = curtime;
 
     // First thing we send a membership query in downstream VIF's...
-    sendGeneralMembershipQuery();
+    sendGeneralMembershipQuery(1);
 
     // Loop until the end...
     for (;;) {

--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -273,7 +273,7 @@ void igmpProxyRun(void) {
     lasttime = curtime;
 
     // First thing we send a membership query in downstream VIF's...
-    sendGeneralMembershipQuery(1);
+    sendGeneralMembershipQuery();
 
     // Loop until the end...
     for (;;) {

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -272,7 +272,8 @@ int getMcGroupSock(void);
  */
 void acceptGroupReport(uint32_t src, uint32_t group);
 void acceptLeaveMessage(uint32_t src, uint32_t group);
-void sendGeneralMembershipQuery(void);
+void acceptMembershipQuery(uint32_t src);
+void sendGeneralMembershipQuery(int routine);
 
 /* callout.c 
 */

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -273,7 +273,8 @@ int getMcGroupSock(void);
 void acceptGroupReport(uint32_t src, uint32_t group);
 void acceptLeaveMessage(uint32_t src, uint32_t group);
 void acceptMembershipQuery(uint32_t src);
-void sendGeneralMembershipQuery(int routine);
+void doSendGeneralMembershipQuery(void);
+void sendGeneralMembershipQuery(void);
 
 /* callout.c 
 */

--- a/src/request.c
+++ b/src/request.c
@@ -258,8 +258,6 @@ void doSendGeneralMembershipQuery(void) {
 
 void sendGeneralMembershipQuery(void) {
     struct  Config  *conf = getCommonConfig();
-    struct  IfDesc  *Dp;
-    int             Ix;
 
     doSendGeneralMembershipQuery();
 


### PR DESCRIPTION
If the conf->queryInterval was much larger than upstream. The igmp snooping will kick out the membership of igmpproxy member. This commit forward upstream MembershipQuery to downstream, ensure that the MembershipReport can be delivered in time.