### PR TITLE
Add last downstream host tracking with quickleave enabled

### DIFF
--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -260,10 +260,10 @@ int leaveMcGroup( int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr );
  */
 void initRouteTable(void);
 void clearAllRoutes(void);
-int insertRoute(uint32_t group, int ifx);
+int insertRoute(uint32_t group, int ifx, uint32_t src);
 int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif);
 void ageActiveRoutes(void);
-void setRouteLastMemberMode(uint32_t group);
+void setRouteLastMemberMode(uint32_t group, uint32_t src);
 int lastMemberGroupAge(uint32_t group);
 int interfaceInRoute(int32_t group, int Ix);
 int getMcGroupSock(void);

--- a/src/request.c
+++ b/src/request.c
@@ -86,7 +86,7 @@ void acceptGroupReport(uint32_t src, uint32_t group) {
         // If we don't have a whitelist we insertRoute and done
         if(sourceVif->allowedgroups == NULL)
         {
-            insertRoute(group, sourceVif->index);
+            insertRoute(group, sourceVif->index, src);
             return;
         }
         // Check if this Request is legit on this interface
@@ -95,7 +95,7 @@ void acceptGroupReport(uint32_t src, uint32_t group) {
             if((group & sn->subnet_mask) == sn->subnet_addr)
             {
                 // The membership report was OK... Insert it into the route table..
-                insertRoute(group, sourceVif->index);
+                insertRoute(group, sourceVif->index, src);
                 return;
         }
     my_log(LOG_INFO, 0, "The group address %s may not be requested from this interface. Ignoring.", inetFmt(group, s1));
@@ -138,7 +138,7 @@ void acceptLeaveMessage(uint32_t src, uint32_t group) {
         gvDesc = (GroupVifDesc*) malloc(sizeof(GroupVifDesc));
 
         // Tell the route table that we are checking for remaining members...
-        setRouteLastMemberMode(group);
+        setRouteLastMemberMode(group, src);
 
         // Call the group spesific membership querier...
         gvDesc->group = group;


### PR DESCRIPTION
IGMP Leave message will now only be sent upstream when the leave is received from the last downstream host in the multicast group. This solves the issue that with quickleave enabled the multicast stream shortly stops on all other devices when one devices sends a leave while other devices on the same downstream interface are still joined on that group. 

Just  disabling quickleave completely is not the solution for this because that causes the uplink to get saturated when fastly changing IPTV channels for example.
