### PR TITLE
Fix an error for timer execute 

### DIFF
--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -338,7 +338,7 @@ void igmpProxyRun(void) {
              * call gettimeofday.
              */
             if (Rt == 0) {
-                curtime.tv_sec = lasttime.tv_sec + secs;
+                curtime.tv_sec = lasttime.tv_sec + secs;// secs must less than 3
                 curtime.tv_nsec = lasttime.tv_nsec;
                 Rt = -1; /* don't do this next time through the loop */
             } else {

--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -297,7 +297,7 @@ void igmpProxyRun(void) {
             timeout = NULL;
         } else {
             timeout->tv_nsec = 0;
-            timeout->tv_sec = (secs > 3) ? 3 : secs; // aimwang: set max timeout
+            timeout->tv_sec = secs = (secs > 3) ? 3 : secs; // aimwang: set max timeout
         }
 
         // Prepare for select.


### PR DESCRIPTION
If not fix , this timer execute every 10s or more。
The variable secs must be assigned and less than 3.Because the timer cycle each 3 seconds.