### PR TITLE
Code Rewrite

### DIFF
--- a/doc/igmpproxy.conf.5.in
+++ b/doc/igmpproxy.conf.5.in
@@ -55,6 +55,23 @@ interface, this function should not be used. Disabling this function increases
 the risk of bandwidth saturation.
 .RE
 
+.B loglevel
+.RS
+Sets the loglevel for the daemon. Must be between 0-7 and corrsponds to unix syslog levels.
+.RE
+
+.B rescanvif
+.RS
+Enables periodic rescanning of interfaces in system. The value specifies the interval
+in seconds, with a minimum of 10 seconds. 0 is disabled. Currently only changes of downstream
+interfaces are supported.
+.RE
+
+.B rescanconf
+.RS
+Enables periodic rescanning of confiuration file. The value specifies the interval
+in seconds, with a minimum of 10 seconds. 0 is disabled. This implies and overrules rescanvif.
+.RE
 
 .B phyint 
 .I interface

--- a/src/config.c
+++ b/src/config.c
@@ -90,7 +90,8 @@ static void initCommonConfig(void) {
 
     // aimwang: default value
     commonConfig.defaultInterfaceState = IF_STATE_DISABLED;
-    commonConfig.rescanVif = 0;
+    commonConfig.rescanVif  = 0;
+    commonConfig.rescanConf = 0;
 }
 
 /**
@@ -98,6 +99,37 @@ static void initCommonConfig(void) {
 */
 struct Config *getCommonConfig(void) {
     return &commonConfig;
+}
+
+// Reloads the configuration file and removes interfaces which were removed from config.
+void reloadConfig() {
+    struct vifconfig *OldConfPtr, *TmpConfPtr;
+
+    // Load the new configuration keep reference to the old.
+    OldConfPtr = vifconf;
+    if ( ! loadConfig(configFilePath) ) my_log(LOG_ERR, 0, "reloadConfig: Unable to load config file.");
+
+    // Rebuild the interfaces config.
+    rebuildIfVc();
+
+    my_log(LOG_DEBUG, 0, "reloadConfig: Config Reloaded. OldConfPtr %x, NewConfPtr, %x", OldConfPtr, vifconf); 
+    // Free all the old mallocd subnetlists and vifconf list.
+    while ( OldConfPtr ) {
+        TmpConfPtr=OldConfPtr->next; // Increment before free or pointers may be invalid.
+        struct SubnetList *TmpNetPtr;
+        for ( ; OldConfPtr->allowednets;  ) {
+            TmpNetPtr = OldConfPtr->allowednets->next;
+            free (OldConfPtr->allowednets);
+            OldConfPtr->allowednets = TmpNetPtr;
+        }
+        for ( ; OldConfPtr->allowedgroups; ) {
+            TmpNetPtr = OldConfPtr->allowedgroups->next;
+            free (OldConfPtr->allowedgroups);
+            OldConfPtr->allowedgroups = TmpNetPtr;
+        }
+	free (OldConfPtr);
+        OldConfPtr = TmpConfPtr;
+    }
 }
 
 /**
@@ -189,9 +221,43 @@ int loadConfig(char *configFile) {
             continue;
         }
         else if(strcmp("rescanvif", token)==0) {
-            // Got a defaultdown token...
-            my_log(LOG_DEBUG, 0, "Config: Need detect new interface.");
-            commonConfig.rescanVif = 1;
+            // Got a rescanvif token...
+            token = nextConfigToken();
+            int intToken = atoi(token);
+            if (intToken != 0 ) {
+                if (intToken<10) intToken=10;
+                my_log(LOG_DEBUG, 0, "Config: Need detect new interface every %ds.", intToken);
+            }
+            commonConfig.rescanVif = intToken;
+
+            // Read next token...
+            token = nextConfigToken();
+            continue;
+        }
+        else if(strcmp("rescanconf", token)==0) {
+            // Got a rescanconf token...
+            token = nextConfigToken();
+            int intToken = atoi(token);
+            if (intToken != 0 ) {
+                if (intToken<10) intToken=10;
+                my_log(LOG_DEBUG, 0, "Config: Need detect config change every %ds.", intToken);
+            }
+            commonConfig.rescanConf = intToken;
+
+            // Read next token...
+            token = nextConfigToken();
+            continue;
+        }
+        else if(strcmp("loglevel", token)==0) {
+            // Got a loglevel token...
+            token = nextConfigToken();
+            int intToken = atoi(token);
+            if (intToken < 0 || intToken > 7) {
+                my_log(LOG_ERR, 0, "Config: Loglevel must be 0 - 7");
+            } else {
+                LogLevel = intToken;
+                my_log(LOG_DEBUG, 0, "Config: LogLevel %d", LogLevel);
+            }
 
             // Read next token...
             token = nextConfigToken();
@@ -260,6 +326,97 @@ void configureVifs(void) {
     }
 }
 
+/* create VIFs for all IP, non-loop interfaces.
+   When argument is not NULL rebuild the interface table.
+*/
+void createVifs(struct IfDescP *RebuildP) {
+    struct IfDesc *Dp, *oDp = NULL;
+    int    vifcount = 0, upsvifcount = 0, Ix = 0;
+    bool   join = 0; 
+
+    // init array to "not set"
+    for ( Ix = 0; Ix < MAX_UPS_VIFS; Ix++) upStreamIfIdx[Ix] = -1;
+
+    if ( RebuildP != NULL ) {
+        // When rebuild, check if interfaces have dissapeared and call delVIF if necessary.
+        for ( oDp=RebuildP->S; oDp<RebuildP->E; oDp++ ) {
+            for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) if ( ! strcmp (oDp->Name, Dp->Name) ) break;
+            if ( Dp == NULL ) {
+                my_log(LOG_DEBUG, 0, "Interface %s disappeared from system", oDp->Name );
+                if ( oDp->index != -1 ) delVIF(oDp);
+            }
+        }
+    }
+
+    for ( Ix = 0; (Dp = getIfByIx(Ix)); Ix++ ) {
+        if ( RebuildP == NULL ) {
+            // Only add vif for valid interfaces on start-up.
+            if ( (Dp->Flags & IFF_LOOPBACK) || (Dp->state != IF_STATE_DOWNSTREAM && Dp->state != IF_STATE_UPSTREAM) ) continue;
+        } else {
+            /* Need rebuild, check if interface is new or already exists (check table below).
+                             old: disabled    new: disabled    -> do nothing
+                             old: disabled    new: downstream  -> addVIF(new), joinmcroutergroups
+                             old: disabled    new: upstream    -> addVIF(new)
+                             old: downstream  new: disabled    -> delVIF(old)
+               state table   old: downstream  new: downstream  -> addvif(new,old)
+                             old: downstream  new: upstream    -> delvif(old), addvif(new)
+                             old: upstream    new: disabled    -> clear routes oldvif, delVIF(old)
+                             old: upstream    new: downstream  -> clear routes oldvif, delvif(old)),addvif(new), joinmcroutergroup
+                             old: upstream    new: upstream    -> addvif(new,old)
+            */
+            for ( oDp=RebuildP->S; oDp<RebuildP->E; oDp++ ) if ( ! strcmp (oDp->Name, Dp->Name) ) break;
+            if ( oDp < RebuildP->E ) {
+                switch (oDp->state) {
+                case IF_STATE_DISABLED:
+                    switch (Dp->state) {
+                    case IF_STATE_DISABLED:   {                                                      continue; }
+                    case IF_STATE_DOWNSTREAM: {                                  oDp=NULL;  join=1;  break; }
+                    case IF_STATE_UPSTREAM:   {                                  oDp=NULL;           break; }
+                    }
+                    break;
+                case IF_STATE_DOWNSTREAM:
+                    switch (Dp->state) {
+                    case IF_STATE_DISABLED:   {                    delVIF(oDp);                      continue; }
+                    case IF_STATE_DOWNSTREAM: {                                                      break; }
+                    case IF_STATE_UPSTREAM:   {                    delVIF(oDp);  oDp=NULL;           break; }
+                    }
+                    break;
+                case IF_STATE_UPSTREAM:
+                    switch (Dp->state) {
+                    case IF_STATE_DISABLED:   { clearRoutes(oDp);  delVIF(oDp);                      continue; }
+                    case IF_STATE_DOWNSTREAM: { clearRoutes(oDp);  delVIF(oDp);  oDp=NULL;  join=1;  break; }
+                    case IF_STATE_UPSTREAM:   {                                                      break; }
+                    }
+                    break;
+                }
+                if (Dp->Flags & IFF_LOOPBACK) continue;
+            } else {
+                // New Interface. Only add valid up/downstream vif.
+                if ( (Dp->Flags & IFF_LOOPBACK) || (Dp->state != IF_STATE_DOWNSTREAM && Dp->state != IF_STATE_UPSTREAM) ) continue;
+                oDp=NULL; 
+            }
+        }
+        if(Dp->state == IF_STATE_UPSTREAM) {
+            if (upsvifcount < MAX_UPS_VIFS -1)
+            {
+                my_log(LOG_DEBUG, 0, "Found upstream IF #%d, will assign as upstream Vif %d",
+                upsvifcount, Ix);
+                upStreamIfIdx[upsvifcount++] = Ix;
+            } else {
+                my_log(LOG_ERR, 0, "Cannot set VIF #%d as upstream as well. Max upstream Vif count is %d",
+                Ix, MAX_UPS_VIFS);
+            }
+        }
+        addVIF( Dp, oDp );
+        if ( join ) joinMcRoutersGroup(Dp);
+        vifcount++;
+    }
+
+    // All vifs created, check if there is an upstream and at least one downstream.
+    if ( upsvifcount == 0 || vifcount == upsvifcount ) {
+        my_log(LOG_ERR, 0, "There must be at least 1 Vif as upstream and 1 as dowstream.");
+    }
+}
 
 /**
 *   Internal function to parse phyint config

--- a/src/ifvc.c
+++ b/src/ifvc.c
@@ -227,7 +227,7 @@ struct IfDesc *getIfByAddress( uint32_t ipaddr ) {
 *   the supplied IP adress. The IP must match a interfaces
 *   subnet, or any configured allowed subnet on a interface.
 */
-struct IfDesc *getIfByVifIndex( unsigned vifindex ) {
+struct IfDesc *getIfByVifIndex( signed vifindex ) {
     struct IfDesc       *Dp;
     if(vifindex>0) {
         for ( Dp = IfDescP.S; Dp < IfDescP.E; Dp++ ) {

--- a/src/ifvc.c
+++ b/src/ifvc.c
@@ -41,7 +41,7 @@ static inline uint32_t s_addr_from_sockaddr(const struct sockaddr *addr) {
     return addr_in.sin_addr.s_addr;
 }
 
-struct IfDesc IfDescVc[ MAX_IF ], *IfDescEp = IfDescVc;
+struct IfDescP IfDescP = { NULL, NULL, 0 };
 
 /* aimwang: add for detect interface and rebuild IfVc record */
 /***************************************************
@@ -50,149 +50,22 @@ struct IfDesc IfDescVc[ MAX_IF ], *IfDescEp = IfDescVc;
  *          So I can check if the file exist then run me and delete the file.
  ***************************************************/
 void rebuildIfVc () {
-    struct ifreq IfVc[ sizeof( IfDescVc ) / sizeof( IfDescVc[ 0 ] )  ];
-    struct ifreq *IfEp;
-    struct ifconf IoCtlReq;
-    struct IfDesc *Dp;
-    struct ifreq  *IfPt, *IfNext;
-    uint32_t addr, subnet, mask;
-    int Sock;
+    // Build new IfDesc Table. Keep Copy of Old.
+    struct IfDescP OldIfDescP=IfDescP, TmpIfDescP=IfDescP;
+    buildIfVc();
 
-    // Get the config.
-    struct Config *config = getCommonConfig();
+    // Call configureVifs to link the new IfDesc table.
+    configureVifs();
 
-    if ( (Sock = socket( AF_INET, SOCK_DGRAM, 0 )) < 0 )
-        my_log( LOG_ERR, errno, "RAW socket open" );
+    // Call createvifs with pointer to old IfDesc table for relinking vifs and removing or adding interfaces if required.
+    my_log (LOG_DEBUG,0,"RebuildIfVc: creating vifs, Old IfDescP: %x, New: %x", OldIfDescP.S, IfDescP.S);
+    createVifs(&OldIfDescP);
 
-    // aimwang: set all downstream IF as lost, for check IF exist or gone.
-    for (Dp = IfDescVc; Dp < IfDescEp; Dp++) {
-        if (Dp->state == IF_STATE_DOWNSTREAM) {
-            Dp->state = IF_STATE_LOST;
-        }
+    // Free the old IfDesc Table.
+    if ( OldIfDescP.S != NULL ) {
+        for (struct IfDesc *Dp = TmpIfDescP.S; Dp < TmpIfDescP.E; Dp++) free(Dp->allowednets);
+        free(OldIfDescP.S);
     }
-
-    IoCtlReq.ifc_buf = (void *)IfVc;
-    IoCtlReq.ifc_len = sizeof( IfVc );
-
-    if ( ioctl( Sock, SIOCGIFCONF, &IoCtlReq ) < 0 )
-        my_log( LOG_ERR, errno, "ioctl SIOCGIFCONF" );
-
-    IfEp = (void *)((char *)IfVc + IoCtlReq.ifc_len);
-
-    for ( IfPt = IfVc; IfPt < IfEp; IfPt = IfNext ) {
-        struct ifreq IfReq;
-        char FmtBu[ 32 ];
-
-        IfNext = (struct ifreq *)((char *)&IfPt->ifr_addr +
-#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
-                IfPt->ifr_addr.sa_len
-#else
-                sizeof(struct sockaddr_in)
-#endif
-        );
-        if (IfNext < IfPt + 1)
-            IfNext = IfPt + 1;
-
-        for (Dp = IfDescVc; Dp < IfDescEp; Dp++) {
-            if (0 == strcmp(Dp->Name, IfPt->ifr_name)) {
-                break;
-            }
-        }
-
-        if (Dp == IfDescEp) {
-            strncpy( Dp->Name, IfPt->ifr_name, sizeof( IfDescEp->Name ) );
-        }
-
-        if ( IfPt->ifr_addr.sa_family != AF_INET ) {
-            if (Dp == IfDescEp) {
-                IfDescEp++;
-            }
-            Dp->InAdr.s_addr = 0;  /* mark as non-IP interface */
-            continue;
-        }
-
-        // Get the interface adress...
-        Dp->InAdr.s_addr = s_addr_from_sockaddr(&IfPt->ifr_addr);
-        addr = Dp->InAdr.s_addr;
-
-        memcpy( IfReq.ifr_name, Dp->Name, sizeof( IfReq.ifr_name ) );
-
-        // Get the subnet mask...
-        if (ioctl(Sock, SIOCGIFNETMASK, &IfReq ) < 0)
-            my_log(LOG_ERR, errno, "ioctl SIOCGIFNETMASK for %s", IfReq.ifr_name);
-        mask = s_addr_from_sockaddr(&IfReq.ifr_addr); // Do not use ifr_netmask as it is not available on freebsd
-        subnet = addr & mask;
-
-        if ( ioctl( Sock, SIOCGIFFLAGS, &IfReq ) < 0 )
-            my_log( LOG_ERR, errno, "ioctl SIOCGIFFLAGS" );
-        Dp->Flags = IfReq.ifr_flags;
-
-        if (0x10d1 == Dp->Flags)
-        {
-            if ( ioctl( Sock, SIOCGIFDSTADDR, &IfReq ) < 0 )
-                my_log(LOG_ERR, errno, "ioctl SIOCGIFDSTADDR for %s", IfReq.ifr_name);
-            addr = s_addr_from_sockaddr(&IfReq.ifr_dstaddr);
-            subnet = addr & mask;
-        }
-
-        if (Dp == IfDescEp) {
-            // Insert the verified subnet as an allowed net...
-            Dp->allowednets = (struct SubnetList *)malloc(sizeof(struct SubnetList));
-            if(IfDescEp->allowednets == NULL) {
-                my_log(LOG_ERR, 0, "Out of memory !");
-            }
-            Dp->allowednets->next = NULL;
-            Dp->state         = IF_STATE_DOWNSTREAM;
-            Dp->robustness    = DEFAULT_ROBUSTNESS;
-            Dp->threshold     = DEFAULT_THRESHOLD;   /* ttl limit */
-            Dp->ratelimit     = DEFAULT_RATELIMIT;
-        }
-
-        // Set the network address for the IF..
-        Dp->allowednets->subnet_mask = mask;
-        Dp->allowednets->subnet_addr = subnet;
-
-        // Set the state for the IF...
-        if (Dp->state == IF_STATE_LOST) {
-            Dp->state         = IF_STATE_DOWNSTREAM;
-        }
-
-        // when IF become enabeld from downstream, addVIF to enable its VIF
-        if (Dp->state == IF_STATE_HIDDEN) {
-            my_log(LOG_NOTICE, 0, "%s [Hidden -> Downstream]", Dp->Name);
-            Dp->state = IF_STATE_DOWNSTREAM;
-            addVIF(Dp);
-            joinMcGroup(getMcGroupSock(), Dp, allrouters_group);
-        }
-
-        // addVIF when found new IF
-        if (Dp == IfDescEp) {
-            my_log(LOG_NOTICE, 0, "%s [New]", Dp->Name);
-            Dp->state = config->defaultInterfaceState;
-            addVIF(Dp);
-            joinMcGroup(getMcGroupSock(), Dp, allrouters_group);
-            IfDescEp++;
-        }
-
-        // Debug log the result...
-        my_log( LOG_DEBUG, 0, "rebuildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s",
-            Dp->Name,
-            fmtInAdr( FmtBu, Dp->InAdr ),
-            Dp->Flags,
-            inetFmts(subnet, mask, s1));
-    }
-
-    // aimwang: search not longer exist IF, set as hidden and call delVIF
-    for (Dp = IfDescVc; Dp < IfDescEp; Dp++) {
-        if (IF_STATE_LOST == Dp->state) {
-            my_log(LOG_NOTICE, 0, "%s [Downstream -> Hidden]", Dp->Name);
-            Dp->state = IF_STATE_HIDDEN;
-            leaveMcGroup( getMcGroupSock(), Dp, allrouters_group );
-            delVIF(Dp);
-        }
-    }
-
-    close( Sock );
 }
 
 /*
@@ -200,130 +73,98 @@ void rebuildIfVc () {
 ** the module will fail if they are called before the vector is build.
 **
 */
-void buildIfVc(void) {
-    struct ifreq IfVc[ sizeof( IfDescVc ) / sizeof( IfDescVc[ 0 ] )  ];
-    struct ifreq *IfEp;
+void buildIfVc() {
+    // Get the config.
     struct Config *config = getCommonConfig();
 
-    int Sock;
+    unsigned int NrInt=0;
+    struct ifaddrs *IfAddrsP, *TmpIfAddrsP;
 
-    if ( (Sock = socket( AF_INET, SOCK_DGRAM, 0 )) < 0 )
-        my_log( LOG_ERR, errno, "RAW socket open" );
-
-    /* get If vector
-     */
-    {
-        struct ifconf IoCtlReq;
-
-        IoCtlReq.ifc_buf = (void *)IfVc;
-        IoCtlReq.ifc_len = sizeof( IfVc );
-
-        if ( ioctl( Sock, SIOCGIFCONF, &IoCtlReq ) < 0 )
-            my_log( LOG_ERR, errno, "ioctl SIOCGIFCONF" );
-
-        IfEp = (void *)((char *)IfVc + IoCtlReq.ifc_len);
+    if ( (getifaddrs (&IfAddrsP)) == -1 ) {
+        my_log ( LOG_ERR, errno, "buildIfVc: getifaddr() failed, cannot enumerate interfaces" );
+        exit (1);
     }
 
-    /* loop over interfaces and copy interface info to IfDescVc
-     */
-    {
-        struct ifreq  *IfPt, *IfNext;
+    // Check nr of interfaces in system.
+    for ( TmpIfAddrsP=IfAddrsP; TmpIfAddrsP; NrInt++) TmpIfAddrsP = TmpIfAddrsP->ifa_next;
+    IfDescP.nrint=NrInt;
+    my_log (LOG_DEBUG, 0 , "buildIfVc: Found %u interface(s) on system", NrInt);
 
+    // Allocate memory for IfDesc Table.
+    struct IfDesc *IfDescA =(struct IfDesc*)calloc(IfDescP.nrint,sizeof(struct IfDesc));
+    if(IfDescA == NULL) my_log(LOG_ERR, 0, "Out of memory !");
+    IfDescP.S=IfDescA;
+    IfDescP.E=IfDescA;
+
+    // loop over interfaces and copy interface info to IfDescP
+    for (TmpIfAddrsP=IfAddrsP; TmpIfAddrsP; TmpIfAddrsP=TmpIfAddrsP->ifa_next) {
         // Temp keepers of interface params...
         uint32_t addr, subnet, mask;
+        char FmtBu[ 32 ];
 
-        for ( IfPt = IfVc; IfPt < IfEp; IfPt = IfNext ) {
-            struct ifreq IfReq;
-            char FmtBu[ 32 ];
+        // don't create IfDesc for non-IP interfaces.
+        if ( TmpIfAddrsP->ifa_addr->sa_family != AF_INET ) continue;
 
-            IfNext = (struct ifreq *)((char *)&IfPt->ifr_addr +
-#ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
-                    IfPt->ifr_addr.sa_len
-#else
-                    sizeof(struct sockaddr_in)
-#endif
-            );
-            if (IfNext < IfPt + 1)
-                IfNext = IfPt + 1;
+        // Copy the interface name.
+        int sz = strlen(TmpIfAddrsP->ifa_name) < sizeof(IfDescP.E->Name) ? strlen(TmpIfAddrsP->ifa_name) : sizeof(IfDescP.E->Name);
+        memcpy( IfDescP.E->Name, TmpIfAddrsP->ifa_name, sz ); IfDescP.E->Name[sz]='\0';
 
-            strncpy( IfDescEp->Name, IfPt->ifr_name, sizeof( IfDescEp->Name ) );
+        // Set the index to -1 by default.
+        IfDescP.E->index = (unsigned int)-1;
 
-            // Currently don't set any allowed nets...
-            //IfDescEp->allowednets = NULL;
+        // Get the interface adress...
+        IfDescP.E->InAdr.s_addr = s_addr_from_sockaddr(TmpIfAddrsP->ifa_addr);
+        addr = IfDescP.E->InAdr.s_addr;
 
-            // Set the index to -1 by default.
-            IfDescEp->index = (unsigned int)-1;
 
-            /* don't retrieve more info for non-IP interfaces
-             */
-            if ( IfPt->ifr_addr.sa_family != AF_INET ) {
-                IfDescEp->InAdr.s_addr = 0;  /* mark as non-IP interface */
-                IfDescEp++;
-                continue;
-            }
+        // Get the subnet mask...
+        mask = s_addr_from_sockaddr(TmpIfAddrsP->ifa_netmask);
+        subnet = addr & mask;
 
-            // Get the interface adress...
-            IfDescEp->InAdr.s_addr = s_addr_from_sockaddr(&IfPt->ifr_addr);
-            addr = IfDescEp->InAdr.s_addr;
+        /* get if flags
+        **
+        ** typical flags:
+        ** lo    0x0049 -> Running, Loopback, Up
+        ** ethx  0x1043 -> Multicast, Running, Broadcast, Up
+        ** ipppx 0x0091 -> NoArp, PointToPoint, Up
+        ** grex  0x00C1 -> NoArp, Running, Up
+        ** ipipx 0x00C1 -> NoArp, Running, Up
+        */
+        IfDescP.E->Flags = TmpIfAddrsP->ifa_flags;
 
-            memcpy( IfReq.ifr_name, IfDescEp->Name, sizeof( IfReq.ifr_name ) );
-
-            // Get the subnet mask...
-            if (ioctl(Sock, SIOCGIFNETMASK, &IfReq ) < 0)
-                my_log(LOG_ERR, errno, "ioctl SIOCGIFNETMASK for %s", IfReq.ifr_name);
-            mask = s_addr_from_sockaddr(&IfReq.ifr_addr); // Do not use ifr_netmask as it is not available on freebsd
+        // aimwang: when pppx get dstaddr for use
+        if (0x10d1 == IfDescP.E->Flags) {
+            addr = s_addr_from_sockaddr(TmpIfAddrsP->ifa_dstaddr);
             subnet = addr & mask;
-
-            /* get if flags
-            **
-            ** typical flags:
-            ** lo    0x0049 -> Running, Loopback, Up
-            ** ethx  0x1043 -> Multicast, Running, Broadcast, Up
-            ** ipppx 0x0091 -> NoArp, PointToPoint, Up
-            ** grex  0x00C1 -> NoArp, Running, Up
-            ** ipipx 0x00C1 -> NoArp, Running, Up
-            */
-            if ( ioctl( Sock, SIOCGIFFLAGS, &IfReq ) < 0 )
-                my_log( LOG_ERR, errno, "ioctl SIOCGIFFLAGS" );
-
-            IfDescEp->Flags = IfReq.ifr_flags;
-
-            // aimwang: when pppx get dstaddr for use
-            if (0x10d1 == IfDescEp->Flags)
-            {
-                if ( ioctl( Sock, SIOCGIFDSTADDR, &IfReq ) < 0 )
-                    my_log(LOG_ERR, errno, "ioctl SIOCGIFDSTADDR for %s", IfReq.ifr_name);
-                addr = s_addr_from_sockaddr(&IfReq.ifr_dstaddr);
-                subnet = addr & mask;
-            }
-
-            // Insert the verified subnet as an allowed net...
-            IfDescEp->allowednets = (struct SubnetList *)malloc(sizeof(struct SubnetList));
-            if(IfDescEp->allowednets == NULL) my_log(LOG_ERR, 0, "Out of memory !");
-
-            // Create the network address for the IF..
-            IfDescEp->allowednets->next = NULL;
-            IfDescEp->allowednets->subnet_mask = mask;
-            IfDescEp->allowednets->subnet_addr = subnet;
-
-            // Set the default params for the IF...
-            IfDescEp->state         = config->defaultInterfaceState;
-            IfDescEp->robustness    = DEFAULT_ROBUSTNESS;
-            IfDescEp->threshold     = DEFAULT_THRESHOLD;   /* ttl limit */
-            IfDescEp->ratelimit     = DEFAULT_RATELIMIT;
-
-            // Debug log the result...
-            my_log( LOG_DEBUG, 0, "buildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s",
-                 IfDescEp->Name,
-                 fmtInAdr( FmtBu, IfDescEp->InAdr ),
-                 IfDescEp->Flags,
-                 inetFmts(subnet,mask, s1));
-
-            IfDescEp++;
         }
-    }
 
-    close( Sock );
+        // Insert the verified subnet as an allowed net...
+        IfDescP.E->allowednets = (struct SubnetList *)malloc(sizeof(struct SubnetList));
+        if(IfDescP.E->allowednets == NULL) my_log(LOG_ERR, 0, "Out of memory !");
+
+        // Create the network address for the IF..
+        IfDescP.E->allowednets->next = NULL;
+        IfDescP.E->allowednets->subnet_mask = mask;
+        IfDescP.E->allowednets->subnet_addr = subnet;
+
+        // Set the default params for the IF...
+        IfDescP.E->state         = config->defaultInterfaceState;
+        IfDescP.E->robustness    = DEFAULT_ROBUSTNESS;
+        IfDescP.E->threshold     = DEFAULT_THRESHOLD;   /* ttl limit */
+        IfDescP.E->ratelimit     = DEFAULT_RATELIMIT;
+
+        // Debug log the result...
+        my_log( LOG_DEBUG, 0, "buildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s",
+             IfDescP.E->Name,
+             fmtInAdr( FmtBu, IfDescP.E->InAdr ),
+             IfDescP.E->Flags,
+             inetFmts(subnet,mask, s1));
+
+        IfDescP.E++;
+    }
+    
+    // Free the getifadds struct.
+    free (IfAddrsP);
 }
 
 /*
@@ -336,7 +177,7 @@ void buildIfVc(void) {
 struct IfDesc *getIfByName( const char *IfName ) {
     struct IfDesc *Dp;
 
-    for ( Dp = IfDescVc; Dp < IfDescEp; Dp++ )
+    for ( Dp = IfDescP.S; Dp < IfDescP.E; Dp++ )
         if ( ! strcmp( IfName, Dp->Name ) )
             return Dp;
 
@@ -351,8 +192,8 @@ struct IfDesc *getIfByName( const char *IfName ) {
 **
 */
 struct IfDesc *getIfByIx( unsigned Ix ) {
-    struct IfDesc *Dp = &IfDescVc[ Ix ];
-    return Dp < IfDescEp ? Dp : NULL;
+    struct IfDesc *Dp = IfDescP.S+Ix;
+    return Dp < IfDescP.E ? Dp : NULL;
 }
 
 /**
@@ -367,7 +208,7 @@ struct IfDesc *getIfByAddress( uint32_t ipaddr ) {
     struct IfDesc       *res = NULL;
     uint32_t            last_subnet_mask = 0;
 
-    for ( Dp = IfDescVc; Dp < IfDescEp; Dp++ ) {
+    for ( Dp = IfDescP.S; Dp < IfDescP.E; Dp++ ) {
         // Loop through all registered allowed nets of the VIF...
         for(currsubnet = Dp->allowednets; currsubnet != NULL; currsubnet = currsubnet->next) {
             // Check if the ip falls in under the subnet....
@@ -389,7 +230,7 @@ struct IfDesc *getIfByAddress( uint32_t ipaddr ) {
 struct IfDesc *getIfByVifIndex( unsigned vifindex ) {
     struct IfDesc       *Dp;
     if(vifindex>0) {
-        for ( Dp = IfDescVc; Dp < IfDescEp; Dp++ ) {
+        for ( Dp = IfDescP.S; Dp < IfDescP.E; Dp++ ) {
             if(Dp->index == vifindex) {
                 return Dp;
             }

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -166,7 +166,7 @@ void acceptIgmp(int recvlen) {
                         }
                     } else {
                         // Activate the route.
-                        int vifindex = checkVIF->index;
+                        unsigned vifindex = checkVIF->index;
                         my_log(LOG_DEBUG, 0, "Route activate request from %s to %s on VIF[%d]",
                             inetFmt(src,s1), inetFmt(dst,s2), vifindex);
                         activateRoute(dst, src, vifindex);

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -329,7 +329,7 @@ void sendIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t group, in
                IP_HEADER_RAOPT_LEN + IGMP_MINLEN + datalen, 0,
                (struct sockaddr *)&sdst, sizeof(sdst)) < 0) {
         if (errno == ENETDOWN)
-            my_log(LOG_ERR, errno, "Sender VIF was down.");
+            my_log(LOG_NOTICE, errno, "Sender VIF was down.");
         else
             my_log(LOG_INFO, errno,
                 "sendto to %s on %s",

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -204,7 +204,7 @@ void buildIfVc( void );
 struct IfDesc *getIfByName( const char *IfName );
 struct IfDesc *getIfByIx( unsigned Ix );
 struct IfDesc *getIfByAddress( uint32_t Ix );
-struct IfDesc *getIfByVifIndex( unsigned vifindex );
+struct IfDesc *getIfByVifIndex( signed vifindex );
 int isAdressValidForIf(struct IfDesc* intrface, uint32_t ipaddr);
 
 /* mroute-api.c

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -35,8 +35,10 @@
 *   igmpproxy.h - Header file for common includes.
 */
 
-#include "config.h"
-#include "os.h"
+#ifndef __FreeBSD__
+    #include "config.h"
+    #include "os.h"
+#endif
 
 #include <errno.h>
 #include <stdarg.h>
@@ -59,6 +61,12 @@
 #include <net/if.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <ifaddrs.h>
+
+#ifdef __FreeBSD__
+    #include "config.h"
+    #include "os.h"
+#endif
 
 /*
  * Limit on length of route data
@@ -113,14 +121,11 @@ void my_log( int Serverity, int Errno, const char *FmtSt, ... );
 
 /* ifvc.c
  */
-#define MAX_IF         40     // max. number of interfaces recognized
 
 // Interface states
 #define IF_STATE_DISABLED      0   // Interface should be ignored.
 #define IF_STATE_UPSTREAM      1   // Interface is the upstream interface
 #define IF_STATE_DOWNSTREAM    2   // Interface is a downstream interface
-#define IF_STATE_LOST          3   // aimwang: Temp from downstream to hidden
-#define IF_STATE_HIDDEN        4   // aimwang: Interface is hidden
 
 // Multicast default values...
 #define DEFAULT_ROBUSTNESS     2
@@ -155,7 +160,13 @@ struct IfDesc {
     unsigned int        robustness;
     unsigned char       threshold;   /* ttl limit */
     unsigned int        ratelimit;
-    unsigned int        index;
+    signed int          index;
+};
+
+struct IfDescP {
+    struct IfDesc       *S;
+    struct IfDesc       *E;
+    unsigned int        nrint;
 };
 
 // Keeps common configuration settings
@@ -175,7 +186,9 @@ struct Config {
     unsigned int        downstreamHostsHashTableSize;
     //~ aimwang added
     // Set if nneed to detect new interface.
-    unsigned short	rescanVif;
+    unsigned short      rescanVif;
+    // Set if nneed to detect config change.
+    unsigned short      rescanConf;
     // Set if not detect new interface for down stream.
     unsigned short	defaultInterfaceState;	// 0: disable, 2: downstream
     //~ aimwang added done
@@ -208,7 +221,7 @@ extern int MRouterFD;
 
 int enableMRouter( void );
 void disableMRouter( void );
-void addVIF( struct IfDesc *Dp );
+void addVIF( struct IfDesc *Dp, struct IfDesc *oDp );
 void delVIF( struct IfDesc *Dp );
 int addMRoute( struct MRouteDesc * Dp );
 int delMRoute( struct MRouteDesc * Dp );
@@ -216,8 +229,11 @@ int getVifIx( struct IfDesc *IfDp );
 
 /* config.c
  */
+char *configFilePath;
+void reloadConfig();
 int loadConfig(char *configFile);
 void configureVifs(void);
+void createVifs(struct IfDescP *rebuildP);
 struct Config *getCommonConfig(void);
 
 /* igmp.c
@@ -261,7 +277,8 @@ int leaveMcGroup( int UdpSock, struct IfDesc *IfDp, uint32_t mcastaddr );
 /* rttable.c
  */
 void initRouteTable(void);
-void clearAllRoutes(void);
+void joinMcRoutersGroup(struct IfDesc *Dp);
+void clearRoutes(struct IfDesc *IfDp);
 int insertRoute(uint32_t group, int ifx, uint32_t src);
 int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif);
 void ageActiveRoutes(void);
@@ -276,16 +293,14 @@ void acceptGroupReport(uint32_t src, uint32_t group);
 void acceptLeaveMessage(uint32_t src, uint32_t group);
 void sendGeneralMembershipQuery(void);
 
-/* callout.c 
+/* callout.c
 */
 typedef void (*timer_f)(void *);
 
 void callout_init(void);
 void free_all_callouts(void);
-void age_callout_queue(int);
-int timer_nextTimer(void);
+void age_callout_queue(struct timespec curtime);
 int timer_setTimer(int, timer_f, void *);
-int timer_clearTimer(int);
 int timer_leftTimer(int);
 
 /* confread.c

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -280,7 +280,7 @@ void initRouteTable(void);
 void joinMcRoutersGroup(struct IfDesc *Dp);
 void clearRoutes(struct IfDesc *IfDp);
 int insertRoute(uint32_t group, int ifx, uint32_t src);
-int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif);
+int activateRoute(uint32_t group, uint32_t originAddr, unsigned upstrVif);
 void ageActiveRoutes(void);
 void setRouteLastMemberMode(uint32_t group, uint32_t src);
 int lastMemberGroupAge(uint32_t group);

--- a/src/rttable.c
+++ b/src/rttable.c
@@ -54,7 +54,7 @@ struct RouteTable {
 
     // Keeps the upstream membership state...
     short               upstrState;     // Upstream membership state.
-    int                 upstrVif;       // Upstream Vif Index.
+    unsigned            upstrVif;       // Upstream Vif Index.
 
     // These parameters contain aging details.
     uint32_t            ageVifBits;     // Bits representing aging VIFs.
@@ -438,7 +438,7 @@ int insertRoute(uint32_t group, int ifx, uint32_t src) {
 *   activated, it's reinstalled in the kernel. If
 *   the route is activated, no originAddr is needed.
 */
-int activateRoute(uint32_t group, uint32_t originAddr, int upstrVif) {
+int activateRoute(uint32_t group, uint32_t originAddr, unsigned upstrVif) {
     struct RouteTable*  croute;
     int result = 0;
 


### PR DESCRIPTION
Rewrite of the base code to fix issues #62 #32 #64 

Overview of changes:
- Rewrite of ifvc.c to account for more dynamic handling of interfaces in system. buildIfVc() was changed to use getifaddrs() instead of socketio to retreive interface info. rebuildIfVc() now uses buildIfVc() instead of doing 90% the same thing.
- Rewrite of callout.c and main event loop to allow for better and simpler timing algorithm. The main loop now no longer needs to care about when timers need to be executed, but only to run the queue aging once every timer resolution (1s).
- Rewrite of config.c to allow for more dynamic handling of interfaces and configuration. for this mroute-api addVif() function was modified for updating or building new vifs when interfaces or configuration change, Split of creation of vifs from igmpproxyInit() into createVifs() function. Added reloadConf() function for reloading configuration on SIGHUP and periodically.
- Added several configuration options (rescanconf / loglevel). Documentation updated. -v command line options are not yet removed to provide backwards compatibility. Fixed rescanvif to do what it actually needs to do.
- Implemented SIGHUP handler to reload configuration / rebuild interfaces.
- Fix for compilation errors on FreeBSD due to incorrect placement of includes on this platform.
- Minor updates to mrouteapi.c (AddVif / Delvif) and rttable.c (clearroutes) to allow for dynamic interfaces.

All this will make the code base much more flexible and readable. The above was achieved while in total 60 lines less code are required. The main event loop timing and timer functions were probably some of the worst I have ever come across. The following snippet of debug logging I did with the old timing says it all. Rebuild timer jumps from 60 secs to 38, within one sec after timers were added. This was because all sorts of weird calculations were being made instead of just maintaining an execution queue in the right order. In turn this was causing timers to execute out of order and/or early.
rebuildtimer: 22 60
About to call timeout 20 (#0)
SENT Membership query   from 192.168.1.254   to 224.0.0.1
Sent membership query from 192.168.1.254 to 224.0.0.1. Delay: 10
Created timeout 23 (#0) - delay 10 secs
(Id:23, Time:10)
(Id:22, Time:28)
Created timeout 24 (#2) - delay 87 secs
(Id:23, Time:10)
(Id:22, Time:28)
(Id:24, Time:87)
rebuildtimer: 22 38

TODO:
Currently only changing of downstream interfaces is supported and this relies on normal aging of routes (stream will continue until route ages). This is because the actual relinking of routetable to changed interfaces is not yet implemented. This will be my next step in the rewrite.