### PR TITLE
Free BSD Compilation Patch

### DIFF
--- a/src/os-freebsd.h
+++ b/src/os-freebsd.h
@@ -1,3 +1,7 @@
+#define __BSD_VISIBLE 1
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <net/route.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip_mroute.h>


### PR DESCRIPTION
Fixes compilation erros on FreeBSD due to missing includes in os-freebsd.h
This was causing errors about undefined structs and types in missing includes.
Also defines __BSD_VISIBLE due to FreeBSD not providing u_int, u_long etc
in a default _POSIX_C_SOURCE environment.
    define  __BSD_VISIBLE 1
    include <sys/param.h>
    include <sys/socket.h>
    include <netinet/in.h>