### PR TITLE
Changes to timing and igmpproxy

### DIFF
--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -80,7 +80,6 @@
 #define BIT_CLR(X,n)     ((X) &= ~(1 << (n)))
 #define BIT_TST(X,n)     ((X) & 1 << (n))
 
-
 //#################################################################################
 //  Globals
 //#################################################################################
@@ -97,7 +96,21 @@ extern char     s2[];
 extern char		s3[];
 extern char		s4[];
 
+/**
+*   Signal Handling.
+*/
+extern unsigned int sighandled;
+extern unsigned int sigstatus;     // 0 = no signal, 1 = SIGHUP, 2 = SIGUSR1, 3 = SIGUSR2, 4 = Timed Reload, 5 = Timed Rebuild
+#define GOT_SIGINT  0x01
+#define GOT_SIGHUP  0x02
+#define GOT_SIGUSR1 0x04
+#define GOT_SIGUSR2 0x08
+#define GOT_SIGURG  0x10
 
+/**
+*   Timekeeping
+*/
+extern struct timespec curtime, lasttime, diftime, utcoff;
 
 //#################################################################################
 //  Lib function prototypes.
@@ -275,17 +288,16 @@ void acceptGroupReport(uint32_t src, uint32_t group);
 void acceptLeaveMessage(uint32_t src, uint32_t group);
 void sendGeneralMembershipQuery(void);
 
-/* callout.c 
+/**
+*   callout.c
 */
 typedef void (*timer_f)(void *);
 
-void callout_init(void);
-void free_all_callouts(void);
-void age_callout_queue(int);
-int timer_nextTimer(void);
-int timer_setTimer(int, timer_f, void *);
-int timer_clearTimer(int);
-int timer_leftTimer(int);
+void timer_freeQueue(void);
+unsigned int timer_ageQueue();
+unsigned int timer_setTimer(int delay, const char name[32], timer_f action, void *);
+struct timespec timer_getTime(unsigned long timer_id);
+void *timer_clearTimer(unsigned long timer_id);
 
 /* confread.c
  */

--- a/src/request.c
+++ b/src/request.c
@@ -202,7 +202,9 @@ void sendGroupSpecificMemberQuery(void *argument) {
     }
 
     // Set timeout for next round...
-    timer_setTimer(conf->lastMemberQueryInterval, sendGroupSpecificMemberQuery, gvDesc);
+    char msg[40] = "Query: ";
+    strcat(msg, inetFmt(gvDesc->group, s1));
+    timer_setTimer(conf->lastMemberQueryInterval, msg, sendGroupSpecificMemberQuery, gvDesc);
 }
 
 
@@ -233,17 +235,17 @@ void sendGeneralMembershipQuery(void) {
     }
 
     // Install timer for aging active routes.
-    timer_setTimer(conf->queryResponseInterval, (timer_f)ageActiveRoutes, NULL);
+    timer_setTimer(conf->queryResponseInterval, "Age Active Routes", (timer_f)ageActiveRoutes, NULL);
 
     // Install timer for next general query...
     if(conf->startupQueryCount>0) {
         // Use quick timer...
-        timer_setTimer(conf->startupQueryInterval, (timer_f)sendGeneralMembershipQuery, NULL);
+        timer_setTimer(conf->startupQueryInterval, "General Query", (timer_f)sendGeneralMembershipQuery, NULL);
         // Decrease startup counter...
         conf->startupQueryCount--;
     }
     else {
         // Use slow timer...
-        timer_setTimer(conf->queryInterval, (timer_f)sendGeneralMembershipQuery, NULL);
+        timer_setTimer(conf->queryInterval, "General Query", (timer_f)sendGeneralMembershipQuery, NULL);
     }
 }

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -37,23 +37,25 @@
 int LogLevel = LOG_WARNING;
 bool Log2Stderr = false;
 
-void my_log( int Severity, int Errno, const char *FmtSt, ... )
-{
+void my_log( int Severity, int Errno, const char *FmtSt, ... ) {
+    struct timespec logtime;
     char LogMsg[ 128 ];
-
     va_list ArgPt;
     unsigned Ln;
+
     va_start( ArgPt, FmtSt );
     Ln = vsnprintf( LogMsg, sizeof( LogMsg ), FmtSt, ArgPt );
-    if( Errno > 0 )
-        snprintf( LogMsg + Ln, sizeof( LogMsg ) - Ln,
-                "; Errno(%d): %s", Errno, strerror(Errno) );
+    if( Errno > 0 ) {
+        snprintf( LogMsg + Ln, sizeof( LogMsg ) - Ln, "; Errno(%d): %s", Errno, strerror(Errno) );
+    }
     va_end( ArgPt );
 
     if (Severity <= LogLevel) {
-        if (Log2Stderr)
-            fprintf(stderr, "%s\n", LogMsg);
-        else {
+        if (Log2Stderr) {
+            clock_gettime(CLOCK_REALTIME, &logtime);
+            long sec = logtime.tv_sec + utcoff.tv_sec, nsec = logtime.tv_nsec;
+            fprintf(stderr, "%02ld:%02ld:%02ld:%04ld %s\n", sec % 86400 / 3600, sec % 3600 / 60, sec % 3600 % 60, nsec / 100000, LogMsg);
+		} else {
             syslog(Severity, "%s", LogMsg);
         }
     }


### PR DESCRIPTION
This commit contains a number of changes to the timing structure and
main event loops.
Also several variables and structs were moved to igmpproxy.h in preperation
to coming changes.
Includes minor changes to config.c and request.c to include new blacklists
for interfaces.
callout.c is modified to a simpler and more stable algorithm.
igmpproxy.h and igmpproxy.c are sanitized and adopted to the new callout queue.

FIXES: https://github.com/pali/igmpproxy/issues/58