### PR TITLE
igmpproxy.c:203 Line cause max timeout is 3 sec,so this line should b…

### DIFF
--- a/src/igmpproxy.c
+++ b/src/igmpproxy.c
@@ -340,7 +340,7 @@ void igmpProxyRun(void) {
              * call gettimeofday.
              */
             if (Rt == 0) {
-                curtime.tv_sec = lasttime.tv_sec + secs;
+                curtime.tv_sec = lasttime.tv_sec + ((secs > 3) ? 3 : secs);
                 curtime.tv_nsec = lasttime.tv_nsec;
                 Rt = -1; /* don't do this next time through the loop */
             } else {


### PR DESCRIPTION
…e the same behavior. otherwise the igmp query time interval will be wrong. slow timer is not 125s or quick timer is no 31 sec