### PR TITLE
Implement sending of IGMPv3 query

### DIFF
--- a/doc/igmpproxy.conf.5.in
+++ b/doc/igmpproxy.conf.5.in
@@ -78,6 +78,15 @@ the risk of bandwidth saturation.
 .RE
 
 
+.B igmpv3
+.RS
+Enables IGMPv3 queries. On default settings, IGMPv1/2 queries are send out.
+With this setting, you can enable IGMPv3 frames for sending queries. This is needed
+for IGMPv3 capable hosts to send IGMPv3 reports. When a IGMPv3 capable host receives
+a IGMPv1/2 query, it answers with a IGMPv1/2 report.
+.RE
+
+
 .B phyint 
 .I interface
 .I role 
@@ -186,6 +195,9 @@ explicitly whitelisted multicast groups will be ignored.
 .SH EXAMPLE
 ## Enable quickleave
 quickleave
+.br
+## Enable IGMPv3 queries instead of IGMPv1/2
+igmpv3
 .br
 ## Define settings for eth0 (upstream)
 .br

--- a/doc/igmpproxy.conf.5.in
+++ b/doc/igmpproxy.conf.5.in
@@ -78,12 +78,14 @@ the risk of bandwidth saturation.
 .RE
 
 
-.B igmpv3
+.B proto
+.I protover
 .RS
-Enables IGMPv3 queries. On default settings, IGMPv1/2 queries are send out.
-With this setting, you can enable IGMPv3 frames for sending queries. This is needed
-for IGMPv3 capable hosts to send IGMPv3 reports. When a IGMPv3 capable host receives
-a IGMPv1/2 query, it answers with a IGMPv1/2 report.
+Specifies IGMP protocol version. On default or whith 'proto igmpv2', IGMPv1/2
+queries are send out. With 'proto igmpv3', you can enable IGMPv3 frames for
+sending queries. This is needed for IGMPv3 capable hosts to send IGMPv3 reports.
+When a IGMPv3 capable host receives a IGMPv1/2 query, it answers with a IGMPv1/2
+report.
 .RE
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -84,6 +84,9 @@ static void initCommonConfig(void) {
     // If 1, a leave message is sent upstream on leave messages from downstream.
     commonConfig.fastUpstreamLeave = 0;
 
+    // If 1, IGMPv3 queries are send instead of IGMPv1/2
+    commonConfig.useIgmpv3 = 0;
+
     // Default size of hash table is 32 bytes (= 256 bits) and can store
     // up to the 256 non-collision hosts, approximately half of /24 subnet
     commonConfig.downstreamHostsHashTableSize = 32;
@@ -219,6 +222,15 @@ int loadConfig(char *configFile) {
                 my_log(LOG_ERR, 0, "Config: user is truncated");
 
             my_log(LOG_DEBUG, 0, "Config: user set to %s", commonConfig.user);
+            token = nextConfigToken();
+            continue;
+        }
+        else if(strcmp("igmpv3", token)==0) {
+            // got an igmpv3 token
+            my_log(LOG_DEBUG, 0, "Config: IGMPv3 mode enabled.");
+            commonConfig.useIgmpv3 = 1;
+
+            // Read next token...
             token = nextConfigToken();
             continue;
         } else {

--- a/src/config.c
+++ b/src/config.c
@@ -225,10 +225,18 @@ int loadConfig(char *configFile) {
             token = nextConfigToken();
             continue;
         }
-        else if(strcmp("igmpv3", token)==0) {
-            // got an igmpv3 token
-            my_log(LOG_DEBUG, 0, "Config: IGMPv3 mode enabled.");
-            commonConfig.useIgmpv3 = 1;
+        else if(strcmp("proto", token)==0) {
+            // IGMP protocol version to use is in next token
+            token = nextConfigToken();
+
+            if (strcmp("igmpv3", token) == 0) {
+                my_log(LOG_DEBUG, 0, "Config: IGMPv3 mode enabled.");
+                commonConfig.useIgmpv3 = 1;
+            }
+            else if (strcmp("igmpv2", token) == 0) {
+                my_log(LOG_DEBUG, 0, "Config: IGMPv2 mode enabled.");
+                commonConfig.useIgmpv3 = 0;
+            }
 
             // Read next token...
             token = nextConfigToken();

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -288,11 +288,11 @@ static void buildIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t g
     igmp->igmp_code         = code;
     igmp->igmp_group.s_addr = group;
     igmp->igmp_cksum        = 0;
-    igmp->igmp_cksum        = inetChksum((unsigned short *)igmp,
-                                         IP_HEADER_RAOPT_LEN + datalen);
     igmp->igmp_misc         = conf->robustnessValue & 0x7;
     igmp->igmp_qqi          = conf->queryInterval;
     igmp->igmp_numsrc       = 0;
+    igmp->igmp_cksum        = inetChksum((unsigned short *)igmp,
+                                IGMP_V3_QUERY_MINLEN + datalen);
 
 }
 

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -262,7 +262,7 @@ void acceptIgmp(int recvlen) {
  */
 static int buildIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t group, int datalen) {
     struct ip *ip;
-    struct igmpv3 *igmp;
+    struct igmpv3_query *igmp;
     struct  Config  *conf = getCommonConfig();
     extern int curttl;
     int query_minlen = IGMP_MINLEN;
@@ -289,7 +289,7 @@ static int buildIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t gr
     ((unsigned char*)send_buf+MIN_IP_HEADER_LEN)[2] = 0x00;
     ((unsigned char*)send_buf+MIN_IP_HEADER_LEN)[3] = 0x00;
 
-    igmp                    = (struct igmpv3 *)(send_buf + IP_HEADER_RAOPT_LEN);
+    igmp                    = (struct igmpv3_query *)(send_buf + IP_HEADER_RAOPT_LEN);
     igmp->igmp_type         = type;
     igmp->igmp_code         = code;
     igmp->igmp_group.s_addr = group;

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -269,7 +269,7 @@ static void buildIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t g
     ip                      = (struct ip *)send_buf;
     ip->ip_src.s_addr       = src;
     ip->ip_dst.s_addr       = dst;
-    ip_set_len(ip, IP_HEADER_RAOPT_LEN + IGMPV3_MINLEN + datalen);
+    ip_set_len(ip, IP_HEADER_RAOPT_LEN + IGMP_V3_QUERY_MINLEN + datalen);
 
     if (IN_MULTICAST(ntohl(dst))) {
         ip->ip_ttl = curttl;
@@ -325,7 +325,7 @@ void sendIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t group, in
 #endif
     sdst.sin_addr.s_addr = dst;
     if (sendto(MRouterFD, send_buf,
-               IP_HEADER_RAOPT_LEN + IGMPV3_MINLEN + datalen, 0,
+               IP_HEADER_RAOPT_LEN + IGMP_V3_QUERY_MINLEN + datalen, 0,
                (struct sockaddr *)&sdst, sizeof(sdst)) < 0) {
         if (errno == ENETDOWN)
             my_log(LOG_ERR, errno, "Sender VIF was down.");

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -175,6 +175,8 @@ struct Config {
     unsigned int        lastMemberQueryCount;
     // Set if upstream leave messages should be sent instantly..
     unsigned short      fastUpstreamLeave;
+    // Set if IGMPv3 should be used for IGMP queries
+    unsigned short      useIgmpv3;
     // Size in bytes of hash table of downstream hosts used for fast leave
     unsigned int        downstreamHostsHashTableSize;
     //~ aimwang added

--- a/src/igmpv3.h
+++ b/src/igmpv3.h
@@ -21,6 +21,21 @@
 *   igmpv3.h - Header file for common IGMPv3 includes.
 */
 
+/*
+ * IGMP v3 query format.
+ */
+struct igmpv3 {
+	u_int8_t		igmp_type;	/* version & type of IGMP message  */
+	u_int8_t		igmp_code;	/* subtype for routing msgs        */
+	u_int16_t		igmp_cksum;	/* IP-style checksum               */
+	struct in_addr	igmp_group;	/* group address being reported    */
+					/*  (zero for queries)             */
+	u_int8_t		igmp_misc;	/* reserved/suppress/robustness    */
+	u_int8_t		igmp_qqi;	/* querier's query interval        */
+	u_int16_t		igmp_numsrc;	/* number of sources               */
+	/*struct in_addr	igmp_sources[1];*/ /* source addresses */
+};
+
 struct igmpv3_grec {
     u_int8_t grec_type;
     u_int8_t grec_auxwords;

--- a/src/igmpv3.h
+++ b/src/igmpv3.h
@@ -24,7 +24,7 @@
 /*
  * IGMP v3 query format.
  */
-struct igmpv3 {
+struct igmpv3_query {
 	u_int8_t		igmp_type;	/* version & type of IGMP message  */
 	u_int8_t		igmp_code;	/* subtype for routing msgs        */
 	u_int16_t		igmp_cksum;	/* IP-style checksum               */
@@ -33,7 +33,7 @@ struct igmpv3 {
 	u_int8_t		igmp_misc;	/* reserved/suppress/robustness    */
 	u_int8_t		igmp_qqi;	/* querier's query interval        */
 	u_int16_t		igmp_numsrc;	/* number of sources               */
-	/*struct in_addr	igmp_sources[1];*/ /* source addresses */
+	struct in_addr	igmp_sources[0]; /* source addresses */
 };
 
 struct igmpv3_grec {

--- a/src/os-linux.h
+++ b/src/os-linux.h
@@ -8,6 +8,7 @@
 #include <linux/mroute.h>
 
 #define IGMP_V3_MEMBERSHIP_REPORT 0x22
+#define IGMP_V3_QUERY_MINLEN IGMPV3_MINLEN
 
 #define INADDR_ALLIGMPV3_GROUP ((in_addr_t) 0xe0000016)
 


### PR DESCRIPTION
According to RFC 2236, IGMPv2/v1 clients should ignore additional fields in query, but build the checksum over the whole IP-Packet. So this is designed for future compatibility and it should be by design to send IGMPv3 queries, when a v3 capable router is in the network.