### PR TITLE
Chroot and drop privileges after startup

### DIFF
--- a/doc/igmpproxy.conf.5.in
+++ b/doc/igmpproxy.conf.5.in
@@ -41,7 +41,29 @@ aliases not in use should be configured as disabled.
 Any line in the configuration file starting with
 .B #
 is treated as a comment. Keywords and parameters can be distributed over many lines.
-The configuration file has two main keywords:
+The configuration file has four main keywords:
+
+.B chroot
+.I directory
+.RS
+Changes the apparent root directory to the given path after startup, thus
+denying
+.B igmpproxy
+access to files and commands outside that environmental directory tree.
+.RE
+
+
+.B user
+.I username
+.RS
+Specifies the userid to which
+.B igmpproxy
+will change after startup.
+.B igmpproxy
+must be started as root, but it will drop root privileges to the specified
+user.
+.RE
+
 
 .B quickleave
 .RS 

--- a/src/config.c
+++ b/src/config.c
@@ -196,6 +196,31 @@ int loadConfig(char *configFile) {
             // Read next token...
             token = nextConfigToken();
             continue;
+        }
+        else if(strcmp("chroot", token)==0) {
+            // path is in next token
+            token = nextConfigToken();
+
+            if (snprintf(commonConfig.chroot, sizeof(commonConfig.chroot), "%s",
+              token) >= (int)sizeof(commonConfig.chroot))
+                my_log(LOG_ERR, 0, "Config: chroot is truncated");
+
+            my_log(LOG_DEBUG, 0, "Config: chroot set to %s",
+              commonConfig.chroot);
+            token = nextConfigToken();
+            continue;
+        }
+        else if(strcmp("user", token)==0) {
+            // username is in next token
+            token = nextConfigToken();
+
+            if (snprintf(commonConfig.user, sizeof(commonConfig.user), "%s",
+              token) >= (int)sizeof(commonConfig.user))
+                my_log(LOG_ERR, 0, "Config: user is truncated");
+
+            my_log(LOG_DEBUG, 0, "Config: user set to %s", commonConfig.user);
+            token = nextConfigToken();
+            continue;
         } else {
             // Unparsable token... Exit...
             closeConfigFile();

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -49,6 +49,9 @@
 #include <fcntl.h>
 #include <stdbool.h>
 #include <time.h>
+#include <grp.h>
+#include <limits.h>
+#include <pwd.h>
 
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -178,6 +181,8 @@ struct Config {
     // Set if not detect new interface for down stream.
     unsigned short	defaultInterfaceState;	// 0: disable, 2: downstream
     //~ aimwang added done
+    char                chroot[PATH_MAX];
+    char                user[LOGIN_NAME_MAX];
 };
 
 // Holds the indeces of the upstream IF...


### PR DESCRIPTION
With this PR:

- The apparent root directory will be changed after startup, thus
  denying igmpproxy access to files and commands outside that
  environmental directory tree. Normally this directory is "/var/empty"
  but that can be over-ridden with a new option in igmpproxy.conf.

- igmpproxy will drop root privileges after startup by changing id to
  another user. Normally this username is "nobody" but this can be
  over-ridden as well.