### PR TITLE
Filter local multicast traffic (#54)

### DIFF
--- a/doc/igmpproxy.conf.5.in
+++ b/doc/igmpproxy.conf.5.in
@@ -41,7 +41,7 @@ aliases not in use should be configured as disabled.
 Any line in the configuration file starting with
 .B #
 is treated as a comment. Keywords and parameters can be distributed over many lines.
-The configuration file has four main keywords:
+The configuration file has five main keywords:
 
 .B chroot
 .I directory
@@ -75,6 +75,17 @@ is not noticed at all by clients on the downstream networks. If it's vital
 that the daemon should act exactly as a real multicast client on the upstream
 interface, this function should not be used. Disabling this function increases
 the risk of bandwidth saturation.
+
+
+.RE
+.B filter
+.I IP-address
+.RS
+Filters traffic to the given IP-address. SSDP / UPNP (239.255.255.250) comes to
+mind, which should be handled locally and not be forwarded to the upstream
+router. This avoids UPnP pollution in double-NAT setups, and open ports
+disclosure in an uncontrolled environment. Use of this option is not necessary
+on a multicast router without NAT. This option can be used multiple times.
 .RE
 
 

--- a/igmpproxy.conf
+++ b/igmpproxy.conf
@@ -25,6 +25,13 @@ quickleave
 
 
 ##------------------------------------------------------
+## Filter traffic to 239.255.255.250 (originating from
+## SSDP / UPnP service)
+##------------------------------------------------------
+filter 239.255.255.250
+
+
+##------------------------------------------------------
 ## Configuration for eth0 (Upstream Interface)
 ##------------------------------------------------------
 phyint eth0 upstream  ratelimit 0  threshold 1

--- a/src/config.c
+++ b/src/config.c
@@ -91,6 +91,8 @@ static void initCommonConfig(void) {
     // aimwang: default value
     commonConfig.defaultInterfaceState = IF_STATE_DISABLED;
     commonConfig.rescanVif = 0;
+
+    commonConfig.filter = NULL;
 }
 
 /**
@@ -219,6 +221,25 @@ int loadConfig(char *configFile) {
                 my_log(LOG_ERR, 0, "Config: user is truncated");
 
             my_log(LOG_DEBUG, 0, "Config: user set to %s", commonConfig.user);
+            token = nextConfigToken();
+            continue;
+        } else if(strcmp("filter", token)==0) {
+            token = nextConfigToken();
+            my_log(LOG_DEBUG, 0, "Config: IF: Got filter token %s.", token);
+
+            struct filter *filter =
+              (struct filter*) malloc(sizeof(struct filter));
+            if(filter == NULL)
+                my_log(LOG_ERR, 0, "Out of memory.");
+
+            if (inet_aton(token, &filter->addr) != 0) {
+                filter->next = commonConfig.filter;
+                commonConfig.filter = filter;
+            } else {
+                free(filter);
+                my_log(LOG_ERR, 0, "Config: IF: invalid address %s.", token);
+            }
+
             token = nextConfigToken();
             continue;
         } else {

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -121,11 +121,15 @@ void acceptIgmp(int recvlen) {
     src       = ip->ip_src.s_addr;
     dst       = ip->ip_dst.s_addr;
 
-    /* filter local multicast 239.255.255.250 */
-    if (dst == htonl(0xEFFFFFFA))
-    {
-        my_log(LOG_NOTICE, 0, "The IGMP message was local multicast. Ignoring.");
-        return;
+    /* Filter traffic */
+    struct filter *filter = getCommonConfig()->filter;
+    while (filter != NULL) {
+        if (dst == filter->addr.s_addr) {
+            my_log(LOG_NOTICE, 0, "IGMP message to %s is filtered",
+              inet_ntoa(filter->addr));
+            return;
+        }
+        filter = filter->next;
     }
 
     /*

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -160,6 +160,12 @@ struct IfDesc {
     unsigned int        index;
 };
 
+// Store multicast address filter
+struct filter {
+    struct in_addr      addr;
+    struct filter       *next;
+};
+
 // Keeps common configuration settings
 struct Config {
     unsigned int        robustnessValue;
@@ -183,6 +189,8 @@ struct Config {
     //~ aimwang added done
     char                chroot[PATH_MAX];
     char                user[LOGIN_NAME_MAX];
+
+    struct filter       *filter;
 };
 
 // Holds the indeces of the upstream IF...


### PR DESCRIPTION
Implement new configuration option (filter), which enables filtering of traffic to a specified IP-address.