### PR TITLE
Use ifindex to identify interfaces

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,12 @@ AC_CHECK_MEMBERS([struct sockaddr_in.sin_len], [], [], [[
 #include <netinet/in.h>
 ]])
 
+# Check for Linux-style extension struct ip_mreqn (Linux, FreeBSD)
+# Adopted from https://github.com/troglobit/smcroute/blob/2.5.6/configure.ac#L144 
+AC_CHECK_MEMBER([struct ip_mreqn.imr_ifindex],
+	AC_DEFINE([HAVE_STRUCT_IP_MREQN], [1], [Define to 1 if you have a Linux-style struct ip_mreqn]),
+	[], [[#include <netinet/in.h>]])
+
 AC_SEARCH_LIBS(socket, socket)
 
 AC_SEARCH_LIBS([clock_gettime],[rt])

--- a/src/ifvc.c
+++ b/src/ifvc.c
@@ -117,6 +117,10 @@ void rebuildIfVc () {
 
         memcpy( IfReq.ifr_name, Dp->Name, sizeof( IfReq.ifr_name ) );
 
+        if (ioctl(Sock, SIOCGIFINDEX, &IfReq ) < 0)
+            my_log(LOG_ERR, errno, "ioctl SIOCGIFINDEX for %s", IfReq.ifr_name);
+        Dp->ifIndex = IfReq.ifr_ifindex;
+
         // Get the subnet mask...
         if (ioctl(Sock, SIOCGIFNETMASK, &IfReq ) < 0)
             my_log(LOG_ERR, errno, "ioctl SIOCGIFNETMASK for %s", IfReq.ifr_name);
@@ -175,8 +179,9 @@ void rebuildIfVc () {
         }
 
         // Debug log the result...
-        my_log( LOG_DEBUG, 0, "rebuildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s",
+        my_log( LOG_DEBUG, 0, "rebuildIfVc: Interface %s Index: %d Addr: %s, Flags: 0x%04x, Network: %s",
             Dp->Name,
+            Dp->ifIndex,
             fmtInAdr( FmtBu, Dp->InAdr ),
             Dp->Flags,
             inetFmts(subnet, mask, s1));
@@ -268,6 +273,10 @@ void buildIfVc(void) {
 
             memcpy( IfReq.ifr_name, IfDescEp->Name, sizeof( IfReq.ifr_name ) );
 
+            if (ioctl(Sock, SIOCGIFINDEX, &IfReq ) < 0)
+                my_log(LOG_ERR, errno, "ioctl SIOCGIFINDEX for %s", IfReq.ifr_name);
+            IfDescEp->ifIndex = IfReq.ifr_ifindex;
+
             // Get the subnet mask...
             if (ioctl(Sock, SIOCGIFNETMASK, &IfReq ) < 0)
                 my_log(LOG_ERR, errno, "ioctl SIOCGIFNETMASK for %s", IfReq.ifr_name);
@@ -313,8 +322,9 @@ void buildIfVc(void) {
             IfDescEp->ratelimit     = DEFAULT_RATELIMIT;
 
             // Debug log the result...
-            my_log( LOG_DEBUG, 0, "buildIfVc: Interface %s Addr: %s, Flags: 0x%04x, Network: %s",
+            my_log( LOG_DEBUG, 0, "buildIfVc: Interface %s Index: %d Addr: %s, Flags: 0x%04x, Network: %s",
                  IfDescEp->Name,
+                 IfDescEp->ifIndex,
                  fmtInAdr( FmtBu, IfDescEp->InAdr ),
                  IfDescEp->Flags,
                  inetFmts(subnet,mask, s1));

--- a/src/igmp.c
+++ b/src/igmp.c
@@ -295,16 +295,18 @@ static void buildIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t g
 /*
  * Call build_igmp() to build an IGMP message in the output packet buffer.
  * Then send the message from the interface with IP address 'src' to
- * destination 'dst'.
+ * destination 'dst'. If struct ip_mreqn is present on the target OS, it is
+ * used instead of 'src' to select the sending interface. 'src' is still used
+ * as the source IP.
  */
-void sendIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t group, int datalen) {
+void sendIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t group, int datalen, int ifidx) {
     struct sockaddr_in sdst;
     int setloop = 0, setigmpsource = 0;
 
     buildIgmp(src, dst, type, code, group, datalen);
 
     if (IN_MULTICAST(ntohl(dst))) {
-        k_set_if(src);
+        k_set_if(src, ifidx);
         setigmpsource = 1;
         if (type != IGMP_DVMRP || dst == allhosts_group) {
             setloop = 1;
@@ -334,7 +336,7 @@ void sendIgmp(uint32_t src, uint32_t dst, int type, int code, uint32_t group, in
             k_set_loop(false);
         }
         // Restore original...
-        k_set_if(INADDR_ANY);
+        k_set_if(INADDR_ANY, 0);
     }
 
     my_log(LOG_DEBUG, 0, "SENT %s from %-15s to %s",

--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -151,6 +151,7 @@ struct SubnetList {
 struct IfDesc {
     char                Name[IF_NAMESIZE];
     struct in_addr      InAdr;          /* == 0 for non IP interfaces */
+    int                 ifIndex;
     short               Flags;
     short               state;
     struct SubnetList*  allowednets;
@@ -232,7 +233,7 @@ extern uint32_t allrouters_group;
 extern uint32_t alligmp3_group;
 void initIgmp(void);
 void acceptIgmp(int);
-void sendIgmp (uint32_t, uint32_t, int, int, uint32_t,int);
+void sendIgmp (uint32_t, uint32_t, int, int, uint32_t, int, int);
 
 /* lib.c
  */
@@ -247,7 +248,7 @@ void k_set_rcvbuf(int bufsize, int minsize);
 void k_hdr_include(int hdrincl);
 void k_set_ttl(int t);
 void k_set_loop(int l);
-void k_set_if(uint32_t ifa);
+void k_set_if(uint32_t ifa, int ifidx);
 void k_join(struct IfDesc *ifd, uint32_t grp);
 void k_leave(struct IfDesc *ifd, uint32_t grp);
 

--- a/src/mroute-api.c
+++ b/src/mroute-api.c
@@ -131,11 +131,17 @@ void addVIF( struct IfDesc *IfDp )
     VifDp->IfDp = IfDp;
 
     VifCtl.vifc_vifi  = VifDp - VifDescVc;
-    VifCtl.vifc_flags = 0;        /* no tunnel, no source routing, register ? */
     VifCtl.vifc_threshold  = VifDp->IfDp->threshold;    // Packet TTL must be at least 1 to pass them
     VifCtl.vifc_rate_limit = VifDp->IfDp->ratelimit;    // Ratelimit
 
+#ifdef VIFF_USE_IFINDEX
+    VifCtl.vifc_flags = VIFF_USE_IFINDEX;
+    VifCtl.vifc_lcl_ifindex = VifDp->IfDp->ifIndex;
+#else
+    VifCtl.vifc_flags = 0;
     VifCtl.vifc_lcl_addr.s_addr = VifDp->IfDp->InAdr.s_addr;
+#endif
+
     VifCtl.vifc_rmt_addr.s_addr = INADDR_ANY;
 
     // Set the index...

--- a/src/request.c
+++ b/src/request.c
@@ -202,7 +202,7 @@ void sendGroupSpecificMemberQuery(void *argument) {
                     sendIgmp(Dp->InAdr.s_addr, gvDesc->group,
                             IGMP_MEMBERSHIP_QUERY,
                             conf->lastMemberQueryInterval * IGMP_TIMER_SCALE,
-                            gvDesc->group, 0);
+                            gvDesc->group, 0, Dp->ifIndex);
 
                     my_log(LOG_DEBUG, 0, "Sent membership query from %s to %s. Delay: %d",
                             inetFmt(Dp->InAdr.s_addr,s1), inetFmt(gvDesc->group,s2),
@@ -232,11 +232,12 @@ void sendGeneralMembershipQuery(void) {
                 // Send the membership query...
                 sendIgmp(Dp->InAdr.s_addr, allhosts_group,
                          IGMP_MEMBERSHIP_QUERY,
-                         conf->queryResponseInterval * IGMP_TIMER_SCALE, 0, 0);
+                         conf->queryResponseInterval * IGMP_TIMER_SCALE, 0, 0, Dp->ifIndex);
 
                 my_log(LOG_DEBUG, 0,
-                    "Sent membership query from %s to %s. Delay: %d",
+                    "Sent membership query from %s ifIndex %d to %s. Delay: %d",
                     inetFmt(Dp->InAdr.s_addr,s1),
+                    Dp->ifIndex,
                     inetFmt(allhosts_group,s2),
                     conf->queryResponseInterval);
             }


### PR DESCRIPTION
I'm using igmpproxy to proxy multicast to a bunch of point-to-point interfaces which are not identified by IP (they all have the same IP with a /32 configured and a point-to-point route to identify the remote end). This didn't work previously because igmpproxy assumed that IPs identify interfaces uniquely, which is not the case in this topology.

This has been tested on Linux 5.15 and works fine there. I haven't tested this on anything else. If this is a problem I'm happy to just keep this in my fork.